### PR TITLE
Bug fixes and enhancements.

### DIFF
--- a/Makefile.ajk
+++ b/Makefile.ajk
@@ -1,0 +1,71 @@
+COMPILE ?= gcc
+BOOT ?= none
+APP ?= 0
+SPI_SPEED ?= 40
+SPI_MODE ?= QIO
+SPI_SIZE_MAP ?= 0
+
+CC = $(CURDIR)/../esp-open-sdk/xtensa-lx106-elf/bin/xtensa-lx106-elf-gcc
+AR = $(CURDIR)/../esp-open-sdk/xtensa-lx106-elf/bin/xtensa-lx106-elf-ar
+DEFS = -DLWIP_OPEN_SRC -DPBUF_RSV_FOR_WLAN -DEBUF_LWIP -DICACHE_FLASH -DMEMCPY=memcpy -DSMEMCPY=memcpy
+COPT = -Os
+CFLAGS = $(DEFS) $(COPT) -Iinclude -Wl,-EL -mlongcalls -mtext-section-literals -mforce-l32 $(CFLAGS_EXTRA)
+# Install prefix of esp-open-sdk toolchain
+PREFIX = $(CURDIR)/../esp-open-sdk/xtensa-lx106-elf
+
+
+OBJS = \
+lwip/core/def.o \
+lwip/core/dhcp.o \
+lwip/core/dns.o \
+lwip/core/init.o \
+lwip/core/mem.o \
+lwip/core/memp.o \
+lwip/core/netif.o \
+lwip/core/pbuf.o \
+lwip/core/raw.o \
+lwip/core/sntp.o \
+lwip/core/stats.o \
+lwip/core/sys_arch.o \
+lwip/core/sys.o \
+lwip/core/tcp.o \
+lwip/core/tcp_in.o \
+lwip/core/tcp_out.o \
+lwip/core/timers.o \
+lwip/core/udp.o \
+lwip/core/ipv4/autoip.o \
+lwip/core/ipv4/icmp.o \
+lwip/core/ipv4/igmp.o \
+lwip/core/ipv4/inet.o \
+lwip/core/ipv4/inet_chksum.o \
+lwip/core/ipv4/ip_addr.o \
+lwip/core/ipv4/ip.o \
+lwip/core/ipv4/ip_route.o \
+lwip/core/ipv4/ip_frag.o \
+lwip/netif/etharp.o \
+lwip/netif/slipif.o \
+lwip/netif/tunif.o \
+lwip/netif/espenc.o \
+lwip/app/espconn.o\
+lwip/app/espconn_udp.o\
+lwip/app/espconn_tcp.o\
+lwip/app/espconn_mdns.o\
+lwip/app/ping.o\
+lwip/app/netio.o\
+lwip/app/dhcpserver.o \
+lwip/app/encdhcpserver.o \
+
+
+LIB = liblwip_open.a
+
+all: $(LIB)
+
+
+$(LIB): $(OBJS)
+	$(AR) rcs $@ $^
+
+install: $(LIB)
+	cp $(LIB) $(PREFIX)/xtensa-lx106-elf/sysroot/usr/lib/
+
+clean:
+	rm -f $(OBJS) $(LIB)

--- a/include/lwip/app/dhcpserver.h
+++ b/include/lwip/app/dhcpserver.h
@@ -1,99 +1,12 @@
 #ifndef __DHCPS_H__
 #define __DHCPS_H__
 
-#define USE_DNS
-
-typedef struct dhcps_state{
-        sint16_t state;
-} dhcps_state;
-
-// ����dhcpclient�Զ����һ��DHCP msg�ṹ��
-typedef struct dhcps_msg {
-        uint8_t op, htype, hlen, hops;
-        uint8_t xid[4];
-        uint16_t secs, flags;
-        uint8_t ciaddr[4];
-        uint8_t yiaddr[4];
-        uint8_t siaddr[4];
-        uint8_t giaddr[4];
-        uint8_t chaddr[16];
-        uint8_t sname[64];
-        uint8_t file[128];
-        uint8_t options[312];
-}dhcps_msg;
-
-#ifndef LWIP_OPEN_SRC
-struct dhcps_lease {
-	bool enable;
-	struct ip_addr start_ip;
-	struct ip_addr end_ip;
-};
-
-enum dhcps_offer_option{
-	OFFER_START = 0x00,
-	OFFER_ROUTER = 0x01,
-	OFFER_END
-};
-#endif
-
-struct dhcps_pool{
-	struct ip_addr ip;
-	uint8 mac[6];
-	uint32 lease_timer;
-};
-
-typedef struct _list_node{
-	void *pnode;
-	struct _list_node *pnext;
-}list_node;
+#define   dhcps_router_enabled(offer)	((offer & OFFER_ROUTER) != 0)
+#include "dhcpserver_common.h"
+#define DHCPS_DEBUG          0
 
 extern uint32 dhcps_lease_time;
 #define DHCPS_LEASE_TIMER  dhcps_lease_time  //0x05A0
-#define DHCPS_MAX_LEASE 0x64
-#define BOOTP_BROADCAST 0x8000
-
-#define DHCP_REQUEST        1
-#define DHCP_REPLY          2
-#define DHCP_HTYPE_ETHERNET 1
-#define DHCP_HLEN_ETHERNET  6
-#define DHCP_MSG_LEN      236
-
-#define DHCPS_SERVER_PORT  67
-#define DHCPS_CLIENT_PORT  68
-
-#define DHCPDISCOVER  1
-#define DHCPOFFER     2
-#define DHCPREQUEST   3
-#define DHCPDECLINE   4
-#define DHCPACK       5
-#define DHCPNAK       6
-#define DHCPRELEASE   7
-
-#define DHCP_OPTION_SUBNET_MASK   1
-#define DHCP_OPTION_ROUTER        3
-#define DHCP_OPTION_DNS_SERVER    6
-#define DHCP_OPTION_REQ_IPADDR   50
-#define DHCP_OPTION_LEASE_TIME   51
-#define DHCP_OPTION_MSG_TYPE     53
-#define DHCP_OPTION_SERVER_ID    54
-#define DHCP_OPTION_INTERFACE_MTU 26
-#define DHCP_OPTION_PERFORM_ROUTER_DISCOVERY 31
-#define DHCP_OPTION_BROADCAST_ADDRESS 28
-#define DHCP_OPTION_REQ_LIST     55
-#define DHCP_OPTION_END         255
-
-//#define USE_CLASS_B_NET 1
-#define DHCPS_DEBUG          0
-#define MAX_STATION_NUM      8
-
-#define DHCPS_STATE_OFFER 1
-#define DHCPS_STATE_DECLINE 2
-#define DHCPS_STATE_ACK 3
-#define DHCPS_STATE_NAK 4
-#define DHCPS_STATE_IDLE 5
-#define DHCPS_STATE_RELEASE 6
-
-#define   dhcps_router_enabled(offer)	((offer & OFFER_ROUTER) != 0)
 
 void dhcps_start(struct ip_info *info);
 void dhcps_stop(void);

--- a/include/lwip/app/dhcpserver_common.h
+++ b/include/lwip/app/dhcpserver_common.h
@@ -1,0 +1,94 @@
+#ifndef __DHCPS_COMMON_H__
+#define __DHCPS_COMMON_H__
+
+#define USE_DNS
+
+typedef struct dhcps_state{
+        sint16_t state;
+} dhcps_state;
+
+// ����dhcpclient�Զ����һ��DHCP msg�ṹ��
+typedef struct dhcps_msg {
+        uint8_t op, htype, hlen, hops;
+        uint8_t xid[4];
+        uint16_t secs, flags;
+        uint8_t ciaddr[4];
+        uint8_t yiaddr[4];
+        uint8_t siaddr[4];
+        uint8_t giaddr[4];
+        uint8_t chaddr[16];
+        uint8_t sname[64];
+        uint8_t file[128];
+        uint8_t options[312];
+}dhcps_msg;
+
+#ifndef LWIP_OPEN_SRC
+struct dhcps_lease {
+	bool enable;
+	struct ip_addr start_ip;
+	struct ip_addr end_ip;
+};
+
+enum dhcps_offer_option{
+	OFFER_START = 0x00,
+	OFFER_ROUTER = 0x01,
+	OFFER_END
+};
+#endif
+
+struct dhcps_pool{
+	struct ip_addr ip;
+	uint8 mac[6];
+	uint32 lease_timer;
+};
+
+typedef struct _list_node{
+	void *pnode;
+	struct _list_node *pnext;
+}list_node;
+
+#define DHCPS_MAX_LEASE 0x64
+#define BOOTP_BROADCAST 0x8000
+
+#define DHCP_REQUEST        1
+#define DHCP_REPLY          2
+#define DHCP_HTYPE_ETHERNET 1
+#define DHCP_HLEN_ETHERNET  6
+#define DHCP_MSG_LEN      236
+
+#define DHCPS_SERVER_PORT  67
+#define DHCPS_CLIENT_PORT  68
+
+#define DHCPDISCOVER  1
+#define DHCPOFFER     2
+#define DHCPREQUEST   3
+#define DHCPDECLINE   4
+#define DHCPACK       5
+#define DHCPNAK       6
+#define DHCPRELEASE   7
+
+#define DHCP_OPTION_SUBNET_MASK   1
+#define DHCP_OPTION_ROUTER        3
+#define DHCP_OPTION_DNS_SERVER    6
+#define DHCP_OPTION_REQ_IPADDR   50
+#define DHCP_OPTION_LEASE_TIME   51
+#define DHCP_OPTION_MSG_TYPE     53
+#define DHCP_OPTION_SERVER_ID    54
+#define DHCP_OPTION_INTERFACE_MTU 26
+#define DHCP_OPTION_PERFORM_ROUTER_DISCOVERY 31
+#define DHCP_OPTION_BROADCAST_ADDRESS 28
+#define DHCP_OPTION_REQ_LIST     55
+#define DHCP_OPTION_END         255
+
+//#define USE_CLASS_B_NET 1
+#define MAX_STATION_NUM      8
+
+#define DHCPS_STATE_OFFER 1
+#define DHCPS_STATE_DECLINE 2
+#define DHCPS_STATE_ACK 3
+#define DHCPS_STATE_NAK 4
+#define DHCPS_STATE_IDLE 5
+#define DHCPS_STATE_RELEASE 6
+
+#endif
+

--- a/include/lwip/app/encdhcpserver.h
+++ b/include/lwip/app/encdhcpserver.h
@@ -1,0 +1,20 @@
+#ifndef __enc_DHCPS_H__
+#define __enc_DHCPS_H__
+
+#define   enc_dhcps_router_enabled(offer)	((offer & OFFER_ROUTER) != 0)
+#include "dhcpserver_common.h"
+
+extern uint32 enc_dhcps_lease_time;
+#define enc_DHCPS_LEASE_TIMER  enc_dhcps_lease_time  //0x05A0
+#define ENCDHCPS_DEBUG          0
+
+
+void enc_dhcps_start(struct netif* enetif);
+void enc_dhcps_stop(void);
+
+void enc_dhcps_set_DNS(struct ip_addr *dns_ip) ICACHE_FLASH_ATTR;
+struct dhcps_pool *enc_dhcps_get_mapping(uint16_t no) ICACHE_FLASH_ATTR;
+void enc_dhcps_set_mapping(struct ip_addr *addr, uint8 *mac, uint32 lease_time) ICACHE_FLASH_ATTR;
+
+#endif
+

--- a/include/lwip/debug.h
+++ b/include/lwip/debug.h
@@ -1,8 +1,8 @@
 /*
  * Copyright (c) 2001-2004 Swedish Institute of Computer Science.
- * All rights reserved. 
- * 
- * Redistribution and use in source and binary forms, with or without modification, 
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
  *
  * 1. Redistributions of source code must retain the above copyright notice,
@@ -11,27 +11,28 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  * 3. The name of the author may not be used to endorse or promote products
- *    derived from this software without specific prior written permission. 
+ *    derived from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED 
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT 
- * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
  * OF SUCH DAMAGE.
  *
  * This file is part of the lwIP TCP/IP stack.
- * 
+ *
  * Author: Adam Dunkels <adam@sics.se>
  *
  */
 #ifndef __LWIP_DEBUG_H__
 #define __LWIP_DEBUG_H__
 
+#include "lwipopts.h"
 #include "lwip/arch.h"
 
 /** lower two bits indicate debug level
@@ -65,7 +66,7 @@
 #define LWIP_ASSERT(message, assertion) do { if(!(assertion)) \
   LWIP_PLATFORM_ASSERT(message); } while(0)
 #else  /* LWIP_NOASSERT */
-#define LWIP_ASSERT(message, assertion) 
+#define LWIP_ASSERT(message, assertion)
 #endif /* LWIP_NOASSERT */
 
 /** if "expression" isn't true, then print "message" and execute "handler" expression */
@@ -91,7 +92,7 @@
                              } while(0)
 
 #else  /* LWIP_DEBUG */
-#define LWIP_DEBUGF(debug, message) 
+#define LWIP_DEBUGF(debug, message)
 #endif /* LWIP_DEBUG */
 
 #endif /* __LWIP_DEBUG_H__ */

--- a/include/lwipopts.h
+++ b/include/lwipopts.h
@@ -6,9 +6,9 @@
 
 /*
  * Copyright (c) 2001-2004 Swedish Institute of Computer Science.
- * All rights reserved. 
- * 
- * Redistribution and use in source and binary forms, with or without modification, 
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
  *
  * 1. Redistributions of source code must retain the above copyright notice,
@@ -17,21 +17,21 @@
  *    this list of conditions and the following disclaimer in the documentation
  *    and/or other materials provided with the distribution.
  * 3. The name of the author may not be used to endorse or promote products
- *    derived from this software without specific prior written permission. 
+ *    derived from this software without specific prior written permission.
  *
- * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED 
- * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF 
- * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT 
- * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, 
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT 
- * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
- * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
- * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING 
- * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+ * OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+ * IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
  * OF SUCH DAMAGE.
  *
  * This file is part of the lwIP TCP/IP stack.
- * 
+ *
  * Author: Adam Dunkels <adam@sics.se>
  *
  */
@@ -54,7 +54,7 @@
 #define SYS_LIGHTWEIGHT_PROT            0
 #endif
 
-/** 
+/**
  * NO_SYS==1: Provides VERY minimal functionality. Otherwise,
  * use lwIP facilities.
  */
@@ -177,8 +177,8 @@
 /**
  * MEMP_USE_CUSTOM_POOLS==1: whether to include a user file lwippools.h
  * that defines additional pools beyond the "standard" ones required
- * by lwIP. If you set this to 1, you must have lwippools.h in your 
- * inlude path somewhere. 
+ * by lwIP. If you set this to 1, you must have lwippools.h in your
+ * inlude path somewhere.
  */
 #ifndef MEMP_USE_CUSTOM_POOLS
 #define MEMP_USE_CUSTOM_POOLS           0
@@ -326,7 +326,7 @@
 
 /**
  * MEMP_NUM_TCPIP_MSG_API: the number of struct tcpip_msg, which are used
- * for callback/timeout API communication. 
+ * for callback/timeout API communication.
  * (only needed if you use tcpip.c)
  */
 #ifndef MEMP_NUM_TCPIP_MSG_API
@@ -335,7 +335,7 @@
 
 /**
  * MEMP_NUM_TCPIP_MSG_INPKT: the number of struct tcpip_msg, which are used
- * for incoming packets. 
+ * for incoming packets.
  * (only needed if you use tcpip.c)
  */
 #ifndef MEMP_NUM_TCPIP_MSG_INPKT
@@ -400,7 +400,7 @@
 #endif
 
 /**
- * PBUF_POOL_SIZE: the number of buffers in the pbuf pool. 
+ * PBUF_POOL_SIZE: the number of buffers in the pbuf pool.
  */
 #ifndef PBUF_POOL_SIZE
 #define PBUF_POOL_SIZE                  10
@@ -499,7 +499,7 @@
 #endif
 
 /**
- * IP_NAPT==1: Enables the ability to do Network Address Port Translation (NAPT) 
+ * IP_NAPT==1: Enables the ability to do Network Address Port Translation (NAPT)
  * on forwarded packets. This only makes sense with IP_FORWARD==1.
  */
 #ifndef IP_NAPT
@@ -728,7 +728,7 @@
 
 /**
  * SNMP_CONCURRENT_REQUESTS: Number of concurrent requests the module will
- * allow. At least one request buffer is required. 
+ * allow. At least one request buffer is required.
  */
 #ifndef SNMP_CONCURRENT_REQUESTS
 #define SNMP_CONCURRENT_REQUESTS        0
@@ -743,7 +743,7 @@
 #endif
 
 /**
- * SNMP_PRIVATE_MIB: 
+ * SNMP_PRIVATE_MIB:
  */
 #ifndef SNMP_PRIVATE_MIB
 #define SNMP_PRIVATE_MIB                0
@@ -789,7 +789,7 @@
    ----------------------------------
 */
 /**
- * LWIP_IGMP==1: Turn on IGMP module. 
+ * LWIP_IGMP==1: Turn on IGMP module.
  */
 #ifndef LWIP_IGMP
 #define LWIP_IGMP                       1
@@ -917,12 +917,12 @@
 #endif
 
 /**
- * TCP_WND: The size of a TCP window.  This must be at least 
+ * TCP_WND: The size of a TCP window.  This must be at least
  * (2 * TCP_MSS) for things to work well
  */
 #ifndef TCP_WND
 #define TCP_WND                         (*(volatile uint32*)0x600011F0)
-#endif 
+#endif
 
 /**
  * TCP_MAXRTX: Maximum number of retransmissions of data segments.
@@ -987,7 +987,7 @@
 
 
 /**
- * TCP_SND_BUF: TCP sender buffer space (bytes). 
+ * TCP_SND_BUF: TCP sender buffer space (bytes).
  */
 #ifndef TCP_SND_BUF
 #define TCP_SND_BUF                     (2 * TCP_MSS)
@@ -1083,7 +1083,7 @@
 #ifndef LWIP_EVENT_API
 #define LWIP_EVENT_API                  0
 #define LWIP_CALLBACK_API               1
-#else 
+#else
 #define LWIP_EVENT_API                  1
 #define LWIP_CALLBACK_API               0
 #endif
@@ -1781,28 +1781,28 @@
 #ifndef CHECKSUM_GEN_IP
 #define CHECKSUM_GEN_IP                 1
 #endif
- 
+
 /**
  * CHECKSUM_GEN_UDP==1: Generate checksums in software for outgoing UDP packets.
  */
 #ifndef CHECKSUM_GEN_UDP
 #define CHECKSUM_GEN_UDP                1
 #endif
- 
+
 /**
  * CHECKSUM_GEN_TCP==1: Generate checksums in software for outgoing TCP packets.
  */
 #ifndef CHECKSUM_GEN_TCP
 #define CHECKSUM_GEN_TCP                1
 #endif
- 
+
 /**
  * CHECKSUM_CHECK_IP==1: Check checksums in software for incoming IP packets.
  */
 #ifndef CHECKSUM_CHECK_IP
 #define CHECKSUM_CHECK_IP               1
 #endif
- 
+
 /**
  * CHECKSUM_CHECK_UDP==1: Check checksums in software for incoming UDP packets.
  */

--- a/include/netif/espenc.h
+++ b/include/netif/espenc.h
@@ -5,8 +5,8 @@ err_t enc28j60_link_output(struct netif *netif, struct pbuf *p);
 err_t enc28j60_init(struct netif *netif);
 struct netif* espenc_init(uint8_t *mac_addr, ip_addr_t *ip, ip_addr_t *mask, ip_addr_t *gw, bool dhcp);
 
-//#define log(s, ...)
-#define log(s, ...) os_printf ("[%s:%s:%d] " s "\n", __FILE__, __FUNCTION__, __LINE__, ##__VA_ARGS__)
+#define log(s, ...)
+//#define log(s, ...) os_printf ("[%s:%s:%d] " s "\n", __FILE__, __FUNCTION__, __LINE__, ##__VA_ARGS__)
 
 #define ESP_CS 15
 #define ESP_INT 5
@@ -236,7 +236,7 @@ struct netif* espenc_init(uint8_t *mac_addr, ip_addr_t *ip, ip_addr_t *mask, ip_
 
 #define RXSTART_INIT        0x0000  // start of RX buffer, (must be zero, Rev. B4 Errata point 5)
 #define RXSTOP_INIT         0x0BFF  // end of RX buffer, room for 2 packets
- 
+
 #define TXSTART_INIT        0x0C00  // start of TX buffer, room for 1 packet
 #define TXSTOP_INIT         0x11FF  // end of TX buffer
 

--- a/lwip/core/ipv4/ip.c
+++ b/lwip/core/ipv4/ip.c
@@ -1,7 +1,7 @@
 /**
  * @file
  * This is the IPv4 layer implementation for incoming and outgoing IP traffic.
- * 
+ *
  * @see ip_frag.c
  *
  */
@@ -185,7 +185,7 @@ ip_route(ip_addr_t *dest)
 #ifdef IP_ROUTING_TAB
   int i;
 //os_printf_plus("ip_route route to %d.%d.%d.%d\r\n",
-//          ip4_addr1_16(dest), ip4_addr2_16(dest), ip4_addr3_16(dest), ip4_addr4_16(dest)); 
+//          ip4_addr1_16(dest), ip4_addr2_16(dest), ip4_addr3_16(dest), ip4_addr4_16(dest));
   /* search route */
   struct route_entry *found_route = ip_find_route(*dest);
   if (found_route) {
@@ -194,7 +194,7 @@ ip_route(ip_addr_t *dest)
     /* now go on and find the netif on which to forward the packet */
     dest = &current_ip_new_dest;
 //os_printf_plus("redirected to %d.%d.%d.%d\r\n",
-//          ip4_addr1_16(dest), ip4_addr2_16(dest), ip4_addr3_16(dest), ip4_addr4_16(dest)); 
+//          ip4_addr1_16(dest), ip4_addr2_16(dest), ip4_addr3_16(dest), ip4_addr4_16(dest));
   }
 #endif /* IP_ROUTING_TAB */
 
@@ -215,7 +215,7 @@ ip_route(ip_addr_t *dest)
     /* This is a hack! Always sends is through the STA interface as default */
     if (netif_is_up(netif)) {
       if (!ip_addr_isbroadcast(dest, netif) && netif == (struct netif *)eagle_lwip_getif(0)) {
-//os_printf_plus("send through netif %c%c%d\r\n", netif->name[0], netif->name[1], netif->num);
+//os_printf_plus("HACK send through netif %c%c%d\r\n", netif->name[0], netif->name[1], netif->num);
         return netif;
       }
     }
@@ -250,7 +250,7 @@ ip_router(ip_addr_t *dest, ip_addr_t *source){
 	/* iterate through netifs */
   	for(netif = netif_list; netif != NULL; netif = netif->next) {
 	    /* network mask matches? */
-		
+
 	    if (netif_is_up(netif)) {
 	      if (ip_addr_netcmp(dest, &(netif->ip_addr), &(netif->netmask))) {
 	        /* return netif on which to forward IP packet */
@@ -539,7 +539,7 @@ ip_napt_find(u8_t proto, u32_t addr, u16_t port, u16_t mport, u8_t dest)
       LWIP_DEBUGF(NAPT_DEBUG, ("found\n"));
       return t;
     }
-    if (dest == 1 && t->proto == proto && t->dest == addr && t->dport == port 
+    if (dest == 1 && t->proto == proto && t->dest == addr && t->dport == port
         && t->mport == mport) {
       t->last = now;
       LWIP_DEBUGF(NAPT_DEBUG, ("found\n"));
@@ -755,7 +755,7 @@ ip_napt_recv(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp)
       ip4_addr3_16(&iphdr->src), ip4_addr4_16(&iphdr->src),
       ip4_addr1_16(&iphdr->dest), ip4_addr2_16(&iphdr->dest),
       ip4_addr3_16(&iphdr->dest), ip4_addr4_16(&iphdr->dest)));
-	  
+
       LWIP_DEBUGF(NAPT_DEBUG, ("sport %u, dport: %u\n",
                         PP_HTONS(tcphdr->src),
                         PP_HTONS(tcphdr->dest)));
@@ -964,7 +964,7 @@ ip_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp)
   }
   /* Do not forward packets onto the same network interface on which
    * they arrived. */
-  if (netif == inp 
+  if (netif == inp
 #ifdef IP_ROUTING_TAB
       /* ... except if it had been routed to another gw */
       && ip_addr_cmp(&current_ip_new_dest, &current_iphdr_dest)
@@ -1006,7 +1006,7 @@ ip_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp)
   }
 
 /*  os_printf("Old: %4x ", PP_NTOHS(IPH_CHKSUM(iphdr)));
- 
+
   IPH_CHKSUM_SET(iphdr, 0);
   IPH_CHKSUM_SET(iphdr, inet_chksum(iphdr, IP_HLEN));
   os_printf("Now: %4x\r\n", PP_NTOHS(IPH_CHKSUM(iphdr)));
@@ -1036,7 +1036,7 @@ return_noroute:
  * forwarded (using ip_forward). The IP checksum is always checked.
  *
  * Finally, the packet is sent to the upper layer protocol input function.
- * 
+ *
  * @param p the received IP packet (p->payload points to IP header)
  * @param inp the netif on which this packet was received
  * @return ERR_OK if the packet was processed (could return ERR_* if it wasn't

--- a/lwip/core/udp.c
+++ b/lwip/core/udp.c
@@ -85,291 +85,311 @@ struct udp_pcb *udp_pcbs;
  *
  */
 void ICACHE_FLASH_ATTR
-udp_input(struct pbuf *p, struct netif *inp)
-{
-  struct udp_hdr *udphdr;
-  struct udp_pcb *pcb, *prev;
-  struct udp_pcb *uncon_pcb;
-  struct ip_hdr *iphdr;
-  u16_t src, dest;
-  u8_t local_match;
-  u8_t broadcast;
+udp_input(struct pbuf *p, struct netif *inp) {
+        struct udp_hdr *udphdr;
+        struct udp_pcb *pcb, *prev;
+        struct udp_pcb *uncon_pcb;
+        struct ip_hdr *iphdr;
+        u16_t src, dest;
+        u8_t local_match;
+        u8_t broadcast;
 
-  PERF_START;
+        PERF_START;
 
-  UDP_STATS_INC(udp.recv);
+        UDP_STATS_INC(udp.recv);
 
-  iphdr = (struct ip_hdr *)p->payload;
+        iphdr = (struct ip_hdr *) p->payload;
 
-  /* Check minimum length (IP header + UDP header)
-   * and move payload pointer to UDP header */
-  if (p->tot_len < (IPH_HL(iphdr) * 4 + UDP_HLEN) || pbuf_header(p, -(s16_t)(IPH_HL(iphdr) * 4))) {
-    /* drop short packets */
-    LWIP_DEBUGF(UDP_DEBUG,
-                ("udp_input: short UDP datagram (%"U16_F" bytes) discarded\n", p->tot_len));
-    UDP_STATS_INC(udp.lenerr);
-    UDP_STATS_INC(udp.drop);
-    snmp_inc_udpinerrors();
-    pbuf_free(p);
-    goto end;
-  }
+        /* Check minimum length (IP header + UDP header)
+         * and move payload pointer to UDP header */
+        if(p->tot_len < (IPH_HL(iphdr) * 4 + UDP_HLEN) || pbuf_header(p, -(s16_t) (IPH_HL(iphdr) * 4))) {
+                /* drop short packets */
+                LWIP_DEBUGF(UDP_DEBUG,
+                        ("udp_input: short UDP datagram (%"U16_F" bytes) discarded\n", p->tot_len));
+                UDP_STATS_INC(udp.lenerr);
+                UDP_STATS_INC(udp.drop);
+                snmp_inc_udpinerrors();
+                pbuf_free(p);
+                goto end;
+        }
 
-  udphdr = (struct udp_hdr *)p->payload;
+        udphdr = (struct udp_hdr *) p->payload;
 
-  /* is broadcast packet ? */
-  broadcast = ip_addr_isbroadcast(&current_iphdr_dest, inp);
+        /* is broadcast packet ? */
+        broadcast = ip_addr_isbroadcast(&current_iphdr_dest, inp);
 
-  LWIP_DEBUGF(UDP_DEBUG, ("udp_input: received datagram of length %"U16_F"\n", p->tot_len));
+        LWIP_DEBUGF(UDP_DEBUG, ("udp_input: received datagram of length %"U16_F"\n", p->tot_len));
 
-  /* convert src and dest ports to host byte order */
-  src = ntohs(udphdr->src);
-  dest = ntohs(udphdr->dest);
+        /* convert src and dest ports to host byte order */
+        src = ntohs(udphdr->src);
+        dest = ntohs(udphdr->dest);
 
-  udp_debug_print(udphdr);
+        udp_debug_print(udphdr);
 
-  /* print the UDP source and destination */
-  LWIP_DEBUGF(UDP_DEBUG,
-              ("udp (%"U16_F".%"U16_F".%"U16_F".%"U16_F", %"U16_F") <-- "
-               "(%"U16_F".%"U16_F".%"U16_F".%"U16_F", %"U16_F")\n",
-               ip4_addr1_16(&iphdr->dest), ip4_addr2_16(&iphdr->dest),
-               ip4_addr3_16(&iphdr->dest), ip4_addr4_16(&iphdr->dest), ntohs(udphdr->dest),
-               ip4_addr1_16(&iphdr->src), ip4_addr2_16(&iphdr->src),
-               ip4_addr3_16(&iphdr->src), ip4_addr4_16(&iphdr->src), ntohs(udphdr->src)));
+        /* print the UDP source and destination */
+        LWIP_DEBUGF(UDP_DEBUG,
+                ("udp (%"U16_F".%"U16_F".%"U16_F".%"U16_F", %"U16_F") <-- "
+                "(%"U16_F".%"U16_F".%"U16_F".%"U16_F", %"U16_F") from %cc\n",
+                ip4_addr1_16(&iphdr->dest), ip4_addr2_16(&iphdr->dest),
+                ip4_addr3_16(&iphdr->dest), ip4_addr4_16(&iphdr->dest), ntohs(udphdr->dest),
+                ip4_addr1_16(&iphdr->src), ip4_addr2_16(&iphdr->src),
+                ip4_addr3_16(&iphdr->src), ip4_addr4_16(&iphdr->src), ntohs(udphdr->src),
+                inp->name[0], inp->name[1]));
 
 #if LWIP_DHCP
-  pcb = NULL;
-  /* when LWIP_DHCP is active, packets to DHCP_CLIENT_PORT may only be processed by
-     the dhcp module, no other UDP pcb may use the local UDP port DHCP_CLIENT_PORT */
-  if (dest == DHCP_CLIENT_PORT) {
-    /* all packets for DHCP_CLIENT_PORT not coming from DHCP_SERVER_PORT are dropped! */
-    if (src == DHCP_SERVER_PORT) {
-      if ((inp->dhcp != NULL) && (inp->dhcp->pcb != NULL)) {
-        /* accept the packe if 
-           (- broadcast or directed to us) -> DHCP is link-layer-addressed, local ip is always ANY!
-           - inp->dhcp->pcb->remote == ANY or iphdr->src */
-        if ((ip_addr_isany(&inp->dhcp->pcb->remote_ip) ||
-           ip_addr_cmp(&(inp->dhcp->pcb->remote_ip), &current_iphdr_src))) {
-          pcb = inp->dhcp->pcb;
-        }
-      }
-    } else if (dest == DHCP_SERVER_PORT) {
-      if (src == DHCP_CLIENT_PORT) {
-        if ( inp->dhcps_pcb != NULL ) {
-          if ((ip_addr_isany(&inp->dhcps_pcb->local_ip) ||
-              ip_addr_cmp(&(inp->dhcps_pcb->local_ip), &current_iphdr_dest))) {
-            pcb = inp->dhcps_pcb;
-          }
-        }
-      }
-    }
-  } else
+        pcb = NULL;
+        /* when LWIP_DHCP is active, packets to DHCP_CLIENT_PORT may only be processed by
+           the dhcp module, no other UDP pcb may use the local UDP port DHCP_CLIENT_PORT */
+        if(dest == DHCP_CLIENT_PORT) {
+                /* all packets for DHCP_CLIENT_PORT not coming from DHCP_SERVER_PORT are dropped! */
+                if(src == DHCP_SERVER_PORT) {
+                        if((inp->dhcp != NULL) && (inp->dhcp->pcb != NULL)) {
+                                /* accept the packe if
+                                   (- broadcast or directed to us) -> DHCP is link-layer-addressed, local ip is always ANY!
+                                   - inp->dhcp->pcb->remote == ANY or iphdr->src */
+                                if((ip_addr_isany(&inp->dhcp->pcb->remote_ip) ||
+                                        ip_addr_cmp(&(inp->dhcp->pcb->remote_ip), &current_iphdr_src))) {
+                                        pcb = inp->dhcp->pcb;
+                                }
+                        }
+                } else if(dest == DHCP_SERVER_PORT) {
+                        if(src == DHCP_CLIENT_PORT) {
+                                if(inp->dhcps_pcb != NULL) {
+                                        if((ip_addr_isany(&inp->dhcps_pcb->local_ip) ||
+                                                ip_addr_cmp(&(inp->dhcps_pcb->local_ip), &current_iphdr_dest))) {
+                                                pcb = inp->dhcps_pcb;
+                                        }
+                                }
+                        }
+                }
+        } else
 #endif /* LWIP_DHCP */
-  {
-    prev = NULL;
-    local_match = 0;
-    uncon_pcb = NULL;
-    /* Iterate through the UDP pcb list for a matching pcb.
-     * 'Perfect match' pcbs (connected to the remote port & ip address) are
-     * preferred. If no perfect match is found, the first unconnected pcb that
-     * matches the local port and ip address gets the datagram. */
-    for (pcb = udp_pcbs; pcb != NULL; pcb = pcb->next) {
-      local_match = 0;
-      /* print the PCB local and remote address */
-      LWIP_DEBUGF(UDP_DEBUG,
-                  ("pcb (%"U16_F".%"U16_F".%"U16_F".%"U16_F", %"U16_F") --- "
-                   "(%"U16_F".%"U16_F".%"U16_F".%"U16_F", %"U16_F")\n",
-                   ip4_addr1_16(&pcb->local_ip), ip4_addr2_16(&pcb->local_ip),
-                   ip4_addr3_16(&pcb->local_ip), ip4_addr4_16(&pcb->local_ip), pcb->local_port,
-                   ip4_addr1_16(&pcb->remote_ip), ip4_addr2_16(&pcb->remote_ip),
-                   ip4_addr3_16(&pcb->remote_ip), ip4_addr4_16(&pcb->remote_ip), pcb->remote_port));
+        {
+                prev = NULL;
+                local_match = 0;
+                uncon_pcb = NULL;
+                /* Iterate through the UDP pcb list for a matching pcb.
+                 * 'Perfect match' pcbs (connected to the remote port & ip address) are
+                 * preferred. If no perfect match is found, the first unconnected pcb that
+                 * matches the local port and ip address gets the datagram. */
 
-      /* compare PCB local addr+port to UDP destination addr+port */
-      if ((pcb->local_port == dest) &&
-          ((!broadcast && ip_addr_isany(&pcb->local_ip)) ||
-           ip_addr_cmp(&(pcb->local_ip), &current_iphdr_dest) ||
+                // that's a bit broken for a broadcast. Broadcast should match on the same interface only
+                for(pcb = udp_pcbs; pcb != NULL; pcb = pcb->next) {
+                        local_match = 0;
+                        /* print the PCB local and remote address */
+                        LWIP_DEBUGF(UDP_DEBUG,
+                                ("pcb (%"U16_F".%"U16_F".%"U16_F".%"U16_F", %"U16_F") --- "
+                                "(%"U16_F".%"U16_F".%"U16_F".%"U16_F", %"U16_F") ",
+                                ip4_addr1_16(&pcb->local_ip), ip4_addr2_16(&pcb->local_ip),
+                                ip4_addr3_16(&pcb->local_ip), ip4_addr4_16(&pcb->local_ip), pcb->local_port,
+                                ip4_addr1_16(&pcb->remote_ip), ip4_addr2_16(&pcb->remote_ip),
+                                ip4_addr3_16(&pcb->remote_ip), ip4_addr4_16(&pcb->remote_ip), pcb->remote_port));
+
+                        /* compare PCB local addr+port to UDP destination addr+port */
+                        if((pcb->local_port == dest) &&
+                                ((!broadcast && ip_addr_isany(&pcb->local_ip)) ||
+                                ip_addr_cmp(&(pcb->local_ip), &current_iphdr_dest) ||
 #if LWIP_IGMP
-           ip_addr_ismulticast(&current_iphdr_dest) ||
+                                ip_addr_ismulticast(&current_iphdr_dest) ||
 #endif /* LWIP_IGMP */
 #if IP_SOF_BROADCAST_RECV
-           (broadcast && (pcb->so_options & SOF_BROADCAST)))) {
+                                (broadcast && (pcb->so_options & SOF_BROADCAST)))) {
 #else  /* IP_SOF_BROADCAST_RECV */
-           (broadcast))) {
+                                (broadcast))) {
 #endif /* IP_SOF_BROADCAST_RECV */
-        local_match = 1;
-        if ((uncon_pcb == NULL) && 
-            ((pcb->flags & UDP_FLAGS_CONNECTED) == 0)) {
-          /* the first unconnected matching PCB */
-          uncon_pcb = pcb;
+                                        // Don't bridge broadcast packets to wrong listener!
+                                        if((broadcast && ip_addr_cmp(&inp->ip_addr, &pcb->local_ip)) || !broadcast || ((!broadcast && ip_addr_isany(&pcb->local_ip)))) {
+                                                local_match = 1;
+                                                LWIP_DEBUGF(UDP_DEBUG, ("local match "));
+                                                if((uncon_pcb == NULL) &&
+                                                        ((pcb->flags & UDP_FLAGS_CONNECTED) == 0)) {
+                                                        /* the first unconnected matching PCB */
+                                                        uncon_pcb = pcb;
+                                                }
+                                        }
+                                }
+                        /* compare PCB remote addr+port to UDP source addr+port */
+                        if((local_match != 0) &&
+                                (pcb->remote_port == src) &&
+                                (ip_addr_isany(&pcb->remote_ip) ||
+                                ip_addr_cmp(&(pcb->remote_ip), &current_iphdr_src))) {
+                                /* the first fully matching PCB */
+                                LWIP_DEBUGF(UDP_DEBUG, ("full match "));
+                                if(prev != NULL) {
+                                        /* move the pcb to the front of udp_pcbs so that is
+                                           found faster next time */
+                                        prev->next = pcb->next;
+                                        pcb->next = udp_pcbs;
+                                        udp_pcbs = pcb;
+                                } else {
+                                        UDP_STATS_INC(udp.cachehit);
+                                }
+                                LWIP_DEBUGF(UDP_DEBUG, ("\n"));
+                                break;
+                        }
+                        LWIP_DEBUGF(UDP_DEBUG, ("\n"));
+                        prev = pcb;
+                }
+                /* no fully matching pcb found? then look for an unconnected pcb */
+                if(pcb == NULL) {
+                        LWIP_DEBUGF(UDP_DEBUG, ("Trying unconnected\n"));
+                        pcb = uncon_pcb;
+                        //                        if(pcb != NULL) // prevent NPE...
+                        //                        LWIP_DEBUGF(UDP_DEBUG,
+                        //                                ("pcb (%"U16_F".%"U16_F".%"U16_F".%"U16_F", %"U16_F") --- "
+                        //                                "(%"U16_F".%"U16_F".%"U16_F".%"U16_F", %"U16_F") ",
+                        //                                ip4_addr1_16(&pcb->local_ip), ip4_addr2_16(&pcb->local_ip),
+                        //                                ip4_addr3_16(&pcb->local_ip), ip4_addr4_16(&pcb->local_ip), pcb->local_port,
+                        //                                ip4_addr1_16(&pcb->remote_ip), ip4_addr2_16(&pcb->remote_ip),
+                        //                                ip4_addr3_16(&pcb->remote_ip), ip4_addr4_16(&pcb->remote_ip), pcb->remote_port));
+                        //
+                }
         }
-      }
-      /* compare PCB remote addr+port to UDP source addr+port */
-      if ((local_match != 0) &&
-          (pcb->remote_port == src) &&
-          (ip_addr_isany(&pcb->remote_ip) ||
-           ip_addr_cmp(&(pcb->remote_ip), &current_iphdr_src))) {
-        /* the first fully matching PCB */
-        if (prev != NULL) {
-          /* move the pcb to the front of udp_pcbs so that is
-             found faster next time */
-          prev->next = pcb->next;
-          pcb->next = udp_pcbs;
-          udp_pcbs = pcb;
-        } else {
-          UDP_STATS_INC(udp.cachehit);
-        }
-        break;
-      }
-      prev = pcb;
-    }
-    /* no fully matching pcb found? then look for an unconnected pcb */
-    if (pcb == NULL) {
-      pcb = uncon_pcb;
-    }
-  }
 
-  /* Check checksum if this is a match or if it was directed at us. */
-  if (pcb != NULL || ip_addr_cmp(&inp->ip_addr, &current_iphdr_dest)) {
-    LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, ("udp_input: calculating checksum\n"));
+        /* Check checksum if this is a match or if it was directed at us. */
+        if(pcb != NULL || ip_addr_cmp(&inp->ip_addr, &current_iphdr_dest)) {
+                LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, ("udp_input: calculating checksum\n"));
 #if LWIP_UDPLITE
-    if (IPH_PROTO(iphdr) == IP_PROTO_UDPLITE) {
-      /* Do the UDP Lite checksum */
+                if(IPH_PROTO(iphdr) == IP_PROTO_UDPLITE) {
+                        /* Do the UDP Lite checksum */
 #if CHECKSUM_CHECK_UDP
-      u16_t chklen = ntohs(udphdr->len);
-      if (chklen < sizeof(struct udp_hdr)) {
-        if (chklen == 0) {
-          /* For UDP-Lite, checksum length of 0 means checksum
-             over the complete packet (See RFC 3828 chap. 3.1) */
-          chklen = p->tot_len;
-        } else {
-          /* At least the UDP-Lite header must be covered by the
-             checksum! (Again, see RFC 3828 chap. 3.1) */
-          UDP_STATS_INC(udp.chkerr);
-          UDP_STATS_INC(udp.drop);
-          snmp_inc_udpinerrors();
-          pbuf_free(p);
-          goto end;
-        }
-      }
-      if (inet_chksum_pseudo_partial(p, &current_iphdr_src, &current_iphdr_dest,
-                             IP_PROTO_UDPLITE, p->tot_len, chklen) != 0) {
-       LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_LEVEL_SERIOUS,
-                   ("udp_input: UDP Lite datagram discarded due to failing checksum\n"));
-        UDP_STATS_INC(udp.chkerr);
-        UDP_STATS_INC(udp.drop);
-        snmp_inc_udpinerrors();
-        pbuf_free(p);
-        goto end;
-      }
+                        u16_t chklen = ntohs(udphdr->len);
+                        if(chklen < sizeof(struct udp_hdr)) {
+                                if(chklen == 0) {
+                                        /* For UDP-Lite, checksum length of 0 means checksum
+                                           over the complete packet (See RFC 3828 chap. 3.1) */
+                                        chklen = p->tot_len;
+                                } else {
+                                        /* At least the UDP-Lite header must be covered by the
+                                           checksum! (Again, see RFC 3828 chap. 3.1) */
+                                        UDP_STATS_INC(udp.chkerr);
+                                        UDP_STATS_INC(udp.drop);
+                                        snmp_inc_udpinerrors();
+                                        pbuf_free(p);
+                                        goto end;
+                                }
+                        }
+                        if(inet_chksum_pseudo_partial(p, &current_iphdr_src, &current_iphdr_dest,
+                                IP_PROTO_UDPLITE, p->tot_len, chklen) != 0) {
+                                LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_LEVEL_SERIOUS,
+                                        ("udp_input: UDP Lite datagram discarded due to failing checksum\n"));
+                                UDP_STATS_INC(udp.chkerr);
+                                UDP_STATS_INC(udp.drop);
+                                snmp_inc_udpinerrors();
+                                pbuf_free(p);
+                                goto end;
+                        }
 #endif /* CHECKSUM_CHECK_UDP */
-    } else
+                } else
 #endif /* LWIP_UDPLITE */
-    {
+                {
 #if CHECKSUM_CHECK_UDP
-      if (udphdr->chksum != 0) {
-        if (inet_chksum_pseudo(p, ip_current_src_addr(), ip_current_dest_addr(),
-                               IP_PROTO_UDP, p->tot_len) != 0) {
-          LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_LEVEL_SERIOUS,
-                      ("udp_input: UDP datagram discarded due to failing checksum\n"));
-          UDP_STATS_INC(udp.chkerr);
-          UDP_STATS_INC(udp.drop);
-          snmp_inc_udpinerrors();
-          pbuf_free(p);
-          goto end;
-        }
-      }
+                        if(udphdr->chksum != 0) {
+                                if(inet_chksum_pseudo(p, ip_current_src_addr(), ip_current_dest_addr(),
+                                        IP_PROTO_UDP, p->tot_len) != 0) {
+                                        LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_LEVEL_SERIOUS,
+                                                ("udp_input: UDP datagram discarded due to failing checksum\n"));
+                                        UDP_STATS_INC(udp.chkerr);
+                                        UDP_STATS_INC(udp.drop);
+                                        snmp_inc_udpinerrors();
+                                        pbuf_free(p);
+                                        goto end;
+                                }
+                        }
 #endif /* CHECKSUM_CHECK_UDP */
-    }
-    if(pbuf_header(p, -UDP_HLEN)) {
-      /* Can we cope with this failing? Just assert for now */
-      LWIP_ASSERT("pbuf_header failed\n", 0);
-      UDP_STATS_INC(udp.drop);
-      snmp_inc_udpinerrors();
-      pbuf_free(p);
-      goto end;
-    }
-    if (pcb != NULL) {
-      snmp_inc_udpindatagrams();
+                }
+                if(pbuf_header(p, -UDP_HLEN)) {
+                        /* Can we cope with this failing? Just assert for now */
+                        LWIP_ASSERT("pbuf_header failed\n", 0);
+                        UDP_STATS_INC(udp.drop);
+                        snmp_inc_udpinerrors();
+                        pbuf_free(p);
+                        goto end;
+                }
+                if(pcb != NULL) {
+                        snmp_inc_udpindatagrams();
 #if SO_REUSE && SO_REUSE_RXTOALL
-      if ((broadcast || ip_addr_ismulticast(&current_iphdr_dest)) &&
-          ((pcb->so_options & SOF_REUSEADDR) != 0)) {
-        /* pass broadcast- or multicast packets to all multicast pcbs
-           if SOF_REUSEADDR is set on the first match */
-        struct udp_pcb *mpcb;
-        u8_t p_header_changed = 0;
-        for (mpcb = udp_pcbs; mpcb != NULL; mpcb = mpcb->next) {
-          if (mpcb != pcb) {
-            /* compare PCB local addr+port to UDP destination addr+port */
-            if ((mpcb->local_port == dest) &&
-                ((!broadcast && ip_addr_isany(&mpcb->local_ip)) ||
-                 ip_addr_cmp(&(mpcb->local_ip), &current_iphdr_dest) ||
+                        if((broadcast || ip_addr_ismulticast(&current_iphdr_dest)) &&
+                                ((pcb->so_options & SOF_REUSEADDR) != 0)) {
+                                /* pass broadcast- or multicast packets to all multicast pcbs
+                                   if SOF_REUSEADDR is set on the first match */
+                                struct udp_pcb *mpcb;
+                                u8_t p_header_changed = 0;
+                                for(mpcb = udp_pcbs; mpcb != NULL; mpcb = mpcb->next) {
+                                        if(mpcb != pcb) {
+
+                                                /* compare PCB local addr+port to UDP destination addr+port */
+                                                if((mpcb->local_port == dest) &&
+                                                        ((!broadcast && ip_addr_isany(&mpcb->local_ip)) ||
+                                                        ip_addr_cmp(&(mpcb->local_ip), &current_iphdr_dest) ||
 #if LWIP_IGMP
-                 ip_addr_ismulticast(&current_iphdr_dest) ||
+                                                        ip_addr_ismulticast(&current_iphdr_dest) ||
 #endif /* LWIP_IGMP */
 #if IP_SOF_BROADCAST_RECV
-                 (broadcast && (mpcb->so_options & SOF_BROADCAST)))) {
+                                                        (broadcast && (mpcb->so_options & SOF_BROADCAST)))) {
 #else  /* IP_SOF_BROADCAST_RECV */
-                 (broadcast))) {
+                                                        (broadcast))) {
 #endif /* IP_SOF_BROADCAST_RECV */
-              /* pass a copy of the packet to all local matches */
-              if (mpcb->recv != NULL) {
-                struct pbuf *q;
-                /* for that, move payload to IP header again */
-                if (p_header_changed == 0) {
-                  pbuf_header(p, (s16_t)((IPH_HL(iphdr) * 4) + UDP_HLEN));
-                  p_header_changed = 1;
-                }
-                q = pbuf_alloc(PBUF_RAW, p->tot_len, PBUF_RAM);
-                if (q != NULL) {
-                  err_t err = pbuf_copy(q, p);
-                  if (err == ERR_OK) {
-                    /* move payload to UDP data */
-                    pbuf_header(q, -(s16_t)((IPH_HL(iphdr) * 4) + UDP_HLEN));
-                    mpcb->recv(mpcb->recv_arg, mpcb, q, ip_current_src_addr(), src);
-                  }
-                }
-              }
-            }
-          }
-        }
-        if (p_header_changed) {
-          /* and move payload to UDP data again */
-          pbuf_header(p, -(s16_t)((IPH_HL(iphdr) * 4) + UDP_HLEN));
-        }
-      }
+                                                                /* pass a copy of the packet to all local matches */
+                                                                if(mpcb->recv != NULL) {
+                                                                        struct pbuf *q;
+                                                                        /* for that, move payload to IP header again */
+                                                                        if(p_header_changed == 0) {
+                                                                                pbuf_header(p, (s16_t) ((IPH_HL(iphdr) * 4) + UDP_HLEN));
+                                                                                p_header_changed = 1;
+                                                                        }
+                                                                        q = pbuf_alloc(PBUF_RAW, p->tot_len, PBUF_RAM);
+                                                                        if(q != NULL) {
+                                                                                err_t err = pbuf_copy(q, p);
+                                                                                if(err == ERR_OK) {
+                                                                                        /* move payload to UDP data */
+                                                                                        pbuf_header(q, -(s16_t) ((IPH_HL(iphdr) * 4) + UDP_HLEN));
+                                                                                        mpcb->recv(mpcb->recv_arg, mpcb, q, ip_current_src_addr(), src);
+                                                                                }
+                                                                        }
+                                                                }
+                                                        }
+                                        }
+                                }
+                                if(p_header_changed) {
+                                        /* and move payload to UDP data again */
+                                        pbuf_header(p, -(s16_t) ((IPH_HL(iphdr) * 4) + UDP_HLEN));
+                                }
+                        }
 #endif /* SO_REUSE && SO_REUSE_RXTOALL */
-      /* callback */
-      if (pcb->recv != NULL) {
-        /* now the recv function is responsible for freeing p */
-        pcb->recv(pcb->recv_arg, pcb, p, ip_current_src_addr(), src);
-      } else {
-        /* no recv function registered? then we have to free the pbuf! */
-        pbuf_free(p);
-        goto end;
-      }
-    } else {
-      LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, ("udp_input: not for us.\n"));
+                        /* callback */
+                        if(pcb->recv != NULL) {
+                                /* now the recv function is responsible for freeing p */
+                                pcb->recv(pcb->recv_arg, pcb, p, ip_current_src_addr(), src);
+                        } else {
+                                /* no recv function registered? then we have to free the pbuf! */
+                                pbuf_free(p);
+                                goto end;
+                        }
+                } else {
+                        LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, ("udp_input: not for us.\n"));
 
 #if LWIP_ICMP
-      /* No match was found, send ICMP destination port unreachable unless
-         destination address was broadcast/multicast. */
-      if (!broadcast &&
-          !ip_addr_ismulticast(&current_iphdr_dest)) {
-        /* move payload pointer back to ip header */
-        pbuf_header(p, (IPH_HL(iphdr) * 4) + UDP_HLEN);
-        LWIP_ASSERT("p->payload == iphdr", (p->payload == iphdr));
-        icmp_dest_unreach(p, ICMP_DUR_PORT);
-      }
+                        /* No match was found, send ICMP destination port unreachable unless
+                           destination address was broadcast/multicast. */
+                        if(!broadcast &&
+                                !ip_addr_ismulticast(&current_iphdr_dest)) {
+                                /* move payload pointer back to ip header */
+                                pbuf_header(p, (IPH_HL(iphdr) * 4) + UDP_HLEN);
+                                LWIP_ASSERT("p->payload == iphdr", (p->payload == iphdr));
+                                icmp_dest_unreach(p, ICMP_DUR_PORT);
+                        }
 #endif /* LWIP_ICMP */
-      UDP_STATS_INC(udp.proterr);
-      UDP_STATS_INC(udp.drop);
-      snmp_inc_udpnoports();
-      pbuf_free(p);
-    }
-  } else {
-    pbuf_free(p);
-  }
+                        UDP_STATS_INC(udp.proterr);
+                        UDP_STATS_INC(udp.drop);
+                        snmp_inc_udpnoports();
+                        pbuf_free(p);
+                }
+        } else {
+                pbuf_free(p);
+        }
 end:
-  PERF_STOP("udp_input");
+        PERF_STOP("udp_input");
 }
 
 /**
@@ -391,22 +411,21 @@ end:
  * @see udp_disconnect() udp_sendto()
  */
 err_t ICACHE_FLASH_ATTR
-udp_send(struct udp_pcb *pcb, struct pbuf *p)
-{
-  /* send to the packet using remote ip and port stored in the pcb */
-  return udp_sendto(pcb, p, &pcb->remote_ip, pcb->remote_port);
+udp_send(struct udp_pcb *pcb, struct pbuf *p) {
+        /* send to the packet using remote ip and port stored in the pcb */
+        return udp_sendto(pcb, p, &pcb->remote_ip, pcb->remote_port);
 }
 
 #if LWIP_CHECKSUM_ON_COPY
+
 /** Same as udp_send() but with checksum
  */
 err_t ICACHE_FLASH_ATTR
 udp_send_chksum(struct udp_pcb *pcb, struct pbuf *p,
-                u8_t have_chksum, u16_t chksum)
-{
-  /* send to the packet using remote ip and port stored in the pcb */
-  return udp_sendto_chksum(pcb, p, &pcb->remote_ip, pcb->remote_port,
-    have_chksum, chksum);
+        u8_t have_chksum, u16_t chksum) {
+        /* send to the packet using remote ip and port stored in the pcb */
+        return udp_sendto_chksum(pcb, p, &pcb->remote_ip, pcb->remote_port,
+                have_chksum, chksum);
 }
 #endif /* LWIP_CHECKSUM_ON_COPY */
 
@@ -422,47 +441,66 @@ udp_send_chksum(struct udp_pcb *pcb, struct pbuf *p,
  *
  * If the PCB already has a remote address association, it will
  * be restored after the data is sent.
- * 
+ *
  * @return lwIP error code (@see udp_send for possible error codes)
  *
  * @see udp_disconnect() udp_send()
  */
 err_t ICACHE_FLASH_ATTR
 udp_sendto(struct udp_pcb *pcb, struct pbuf *p,
-  ip_addr_t *dst_ip, u16_t dst_port)
-{
+        ip_addr_t *dst_ip, u16_t dst_port) {
 #if LWIP_CHECKSUM_ON_COPY
-  return udp_sendto_chksum(pcb, p, dst_ip, dst_port, 0, 0);
+        return udp_sendto_chksum(pcb, p, dst_ip, dst_port, 0, 0);
 }
 
 /** Same as udp_sendto(), but with checksum */
 err_t ICACHE_FLASH_ATTR
 udp_sendto_chksum(struct udp_pcb *pcb, struct pbuf *p, ip_addr_t *dst_ip,
-                  u16_t dst_port, u8_t have_chksum, u16_t chksum)
-{
+        u16_t dst_port, u8_t have_chksum, u16_t chksum) {
 #endif /* LWIP_CHECKSUM_ON_COPY */
-  struct netif *netif;
+        struct netif *netif;
 
-  LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, ("udp_send\n"));
+        LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, ("udp_send\n"));
 
-  /* find the outgoing network interface for this packet */
+        /* find the outgoing network interface for this packet */
+#if 0
+        // convoluted...
 #if LWIP_IGMP
-  netif = ip_route((ip_addr_ismulticast(dst_ip))?(&(pcb->multicast_ip)):(dst_ip));
+        netif = ip_route((ip_addr_ismulticast(dst_ip))?(&(pcb->multicast_ip)):(dst_ip));
 #else
-  netif = ip_route(dst_ip);
+          netif = ip_route(dst_ip);
 #endif /* LWIP_IGMP */
+#else
+#if LWIP_IGMP
+        if(ip_addr_ismulticast(dst_ip)) {
+                LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, ("udp_send: dest is multicast\n"));
+                netif = ip_route(&(pcb->multicast_ip));
 
-  /* no outgoing network interface could be found? */
-  if (netif == NULL) {
-    LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_LEVEL_SERIOUS, ("udp_send: No route to %"U16_F".%"U16_F".%"U16_F".%"U16_F"\n",
-      ip4_addr1_16(dst_ip), ip4_addr2_16(dst_ip), ip4_addr3_16(dst_ip), ip4_addr4_16(dst_ip)));
-    UDP_STATS_INC(udp.rterr);
-    return ERR_RTE;
-  }
+        } else
+#endif
+                // COULD be a broadcast, use the hint in the pcb!
+                if(dst_ip->addr = IPADDR_BROADCAST) {
+                LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, ("udp_send: dest is broadcast\n"));
+                netif = ip_route((&(pcb->local_ip)));
+
+        } else {
+                LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, ("udp_send: dest is normal\n"));
+                netif = ip_route(dst_ip);
+        }
+#endif
+
+        /* no outgoing network interface could be found? */
+        if(netif == NULL) {
+                LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_LEVEL_SERIOUS, ("udp_send: No route to %"U16_F".%"U16_F".%"U16_F".%"U16_F"\n",
+                        ip4_addr1_16(dst_ip), ip4_addr2_16(dst_ip), ip4_addr3_16(dst_ip), ip4_addr4_16(dst_ip)));
+                UDP_STATS_INC(udp.rterr);
+                return ERR_RTE;
+        }
+
 #if LWIP_CHECKSUM_ON_COPY
-  return udp_sendto_if_chksum(pcb, p, dst_ip, dst_port, netif, have_chksum, chksum);
+        return udp_sendto_if_chksum(pcb, p, dst_ip, dst_port, netif, have_chksum, chksum);
 #else /* LWIP_CHECKSUM_ON_COPY */
-  return udp_sendto_if(pcb, p, dst_ip, dst_port, netif);
+        return udp_sendto_if(pcb, p, dst_ip, dst_port, netif);
 #endif /* LWIP_CHECKSUM_ON_COPY */
 }
 
@@ -487,208 +525,209 @@ udp_sendto_chksum(struct udp_pcb *pcb, struct pbuf *p, ip_addr_t *dst_ip,
  */
 err_t ICACHE_FLASH_ATTR
 udp_sendto_if(struct udp_pcb *pcb, struct pbuf *p,
-  ip_addr_t *dst_ip, u16_t dst_port, struct netif *netif)
-{
+        ip_addr_t *dst_ip, u16_t dst_port, struct netif *netif) {
 #if LWIP_CHECKSUM_ON_COPY
-  return udp_sendto_if_chksum(pcb, p, dst_ip, dst_port, netif, 0, 0);
+        return udp_sendto_if_chksum(pcb, p, dst_ip, dst_port, netif, 0, 0);
 }
 
 /** Same as udp_sendto_if(), but with checksum */
 err_t ICACHE_FLASH_ATTR
 udp_sendto_if_chksum(struct udp_pcb *pcb, struct pbuf *p, ip_addr_t *dst_ip,
-                     u16_t dst_port, struct netif *netif, u8_t have_chksum,
-                     u16_t chksum)
-{
+        u16_t dst_port, struct netif *netif, u8_t have_chksum,
+        u16_t chksum) {
 #endif /* LWIP_CHECKSUM_ON_COPY */
-  struct udp_hdr *udphdr;
-  ip_addr_t *src_ip;
-  err_t err;
-  struct pbuf *q; /* q will be sent down the stack */
+        struct udp_hdr *udphdr;
+        ip_addr_t *src_ip;
+        err_t err;
+        struct pbuf *q; /* q will be sent down the stack */
 
 #if IP_SOF_BROADCAST
-  /* broadcast filter? */
-  if ( ((pcb->so_options & SOF_BROADCAST) == 0) && ip_addr_isbroadcast(dst_ip, netif) ) {
-    LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_LEVEL_SERIOUS,
-      ("udp_sendto_if: SOF_BROADCAST not enabled on pcb %p\n", (void *)pcb));
-    return ERR_VAL;
-  }
+        /* broadcast filter? */
+        if(((pcb->so_options & SOF_BROADCAST) == 0) && ip_addr_isbroadcast(dst_ip, netif)) {
+                LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_LEVEL_SERIOUS,
+                        ("udp_sendto_if: SOF_BROADCAST not enabled on pcb %p\n", (void *) pcb));
+                return ERR_VAL;
+        }
 #endif /* IP_SOF_BROADCAST */
 
-  /* if the PCB is not yet bound to a port, bind it here */
-  if (pcb->local_port == 0) {
-    LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, ("udp_send: not yet bound to a port, binding now\n"));
-    err = udp_bind(pcb, &pcb->local_ip, pcb->local_port);
-    if (err != ERR_OK) {
-      LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_LEVEL_SERIOUS, ("udp_send: forced port bind failed\n"));
-      return err;
-    }
-  }
+        /* if the PCB is not yet bound to a port, bind it here */
+        if(pcb->local_port == 0) {
+                LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, ("udp_send: not yet bound to a port, binding now\n"));
+                err = udp_bind(pcb, &pcb->local_ip, pcb->local_port);
+                if(err != ERR_OK) {
+                        LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_LEVEL_SERIOUS, ("udp_send: forced port bind failed\n"));
+                        return err;
+                }
+        }
 
-  /* not enough space to add an UDP header to first pbuf in given p chain? */
-  if (pbuf_header(p, UDP_HLEN)) {
-    /* allocate header in a separate new pbuf */
-    q = pbuf_alloc(PBUF_IP, UDP_HLEN, PBUF_RAM);
-    /* new header pbuf could not be allocated? */
-    if (q == NULL) {
-      LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_LEVEL_SERIOUS, ("udp_send: could not allocate header\n"));
-      return ERR_MEM;
-    }
-    if (p->tot_len != 0) {
-      /* chain header q in front of given pbuf p (only if p contains data) */
-      pbuf_chain(q, p);
-    }
-    /* first pbuf q points to header pbuf */
-    LWIP_DEBUGF(UDP_DEBUG,
-                ("udp_send: added header pbuf %p before given pbuf %p\n", (void *)q, (void *)p));
-  } else {
-    /* adding space for header within p succeeded */
-    /* first pbuf q equals given pbuf */
-    q = p;
-    LWIP_DEBUGF(UDP_DEBUG, ("udp_send: added header in given pbuf %p\n", (void *)p));
-  }
-  LWIP_ASSERT("check that first pbuf can hold struct udp_hdr",
-              (q->len >= sizeof(struct udp_hdr)));
-  /* q now represents the packet to be sent */
-  udphdr = (struct udp_hdr *)q->payload;
-  udphdr->src = htons(pcb->local_port);
-  udphdr->dest = htons(dst_port);
-  /* in UDP, 0 checksum means 'no checksum' */
-  udphdr->chksum = 0x0000; 
+        /* not enough space to add an UDP header to first pbuf in given p chain? */
+        if(pbuf_header(p, UDP_HLEN)) {
+                /* allocate header in a separate new pbuf */
+                q = pbuf_alloc(PBUF_IP, UDP_HLEN, PBUF_RAM);
+                /* new header pbuf could not be allocated? */
+                if(q == NULL) {
+                        LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_LEVEL_SERIOUS, ("udp_send: could not allocate header\n"));
+                        return ERR_MEM;
+                }
+                if(p->tot_len != 0) {
+                        /* chain header q in front of given pbuf p (only if p contains data) */
+                        pbuf_chain(q, p);
+                }
+                /* first pbuf q points to header pbuf */
+                LWIP_DEBUGF(UDP_DEBUG,
+                        ("udp_send: added header pbuf %p before given pbuf %p\n", (void *) q, (void *) p));
+        } else {
+                /* adding space for header within p succeeded */
+                /* first pbuf q equals given pbuf */
+                q = p;
+                LWIP_DEBUGF(UDP_DEBUG, ("udp_send: added header in given pbuf %p\n", (void *) p));
+        }
+        LWIP_ASSERT("check that first pbuf can hold struct udp_hdr",
+                (q->len >= sizeof(struct udp_hdr)));
+        /* q now represents the packet to be sent */
+        udphdr = (struct udp_hdr *) q->payload;
+        udphdr->src = htons(pcb->local_port);
+        udphdr->dest = htons(dst_port);
+        /* in UDP, 0 checksum means 'no checksum' */
+        udphdr->chksum = 0x0000;
 
-  /* Multicast Loop? */
+        /* Multicast Loop? */
 #if LWIP_IGMP
-  if (ip_addr_ismulticast(dst_ip) && ((pcb->flags & UDP_FLAGS_MULTICAST_LOOP) != 0)) {
-    q->flags |= PBUF_FLAG_MCASTLOOP;
-  }
+        if(ip_addr_ismulticast(dst_ip) && ((pcb->flags & UDP_FLAGS_MULTICAST_LOOP) != 0)) {
+                q->flags |= PBUF_FLAG_MCASTLOOP;
+        }
 #endif /* LWIP_IGMP */
 
 
-  /* PCB local address is IP_ANY_ADDR? */
-  if (ip_addr_isany(&pcb->local_ip)) {
-    /* use outgoing network interface IP address as source address */
-    src_ip = &(netif->ip_addr);
-  } else {
-    /* check if UDP PCB local IP address is correct
-     * this could be an old address if netif->ip_addr has changed */
-    if (!ip_addr_cmp(&(pcb->local_ip), &(netif->ip_addr))) {
-      /* local_ip doesn't match, drop the packet */
-      if (q != p) {
-        /* free the header pbuf */
-        pbuf_free(q);
-        q = NULL;
-        /* p is still referenced by the caller, and will live on */
-      }
-      return ERR_VAL;
-    }
-    /* use UDP PCB local IP address as source address */
-    src_ip = &(pcb->local_ip);
-  }
+        /* PCB local address is IP_ANY_ADDR? */
+        if(ip_addr_isany(&pcb->local_ip)) {
+                /* use outgoing network interface IP address as source address */
+                src_ip = &(netif->ip_addr);
+        } else {
 
-  LWIP_DEBUGF(UDP_DEBUG, ("udp_send: sending datagram of length %"U16_F"\n", q->tot_len));
+
+                /* check if UDP PCB local IP address is correct
+                 * this could be an old address if netif->ip_addr has changed */
+                if(!ip_addr_cmp(&(pcb->local_ip), &(netif->ip_addr))) {
+                        /* local_ip doesn't match, drop the packet */
+                        LWIP_DEBUGF(UDP_DEBUG, ("udp_send: local_ip doesn't match %"U16_F".%"U16_F".%"U16_F".%"U16_F" != %"U16_F".%"U16_F".%"U16_F".%"U16_F"\n", ip4_addr1_16(&pcb->local_ip), ip4_addr2_16(&pcb->local_ip), ip4_addr3_16(&pcb->local_ip), ip4_addr4_16(&pcb->local_ip), ip4_addr1_16(&netif->ip_addr), ip4_addr2_16(&netif->ip_addr), ip4_addr3_16(&netif->ip_addr), ip4_addr4_16(&netif->ip_addr)));
+                        if(q != p) {
+                                /* free the header pbuf */
+                                pbuf_free(q);
+                                q = NULL;
+                                /* p is still referenced by the caller, and will live on */
+                        }
+                        return ERR_VAL;
+                }
+                /* use UDP PCB local IP address as source address */
+                src_ip = &(pcb->local_ip);
+        }
+
+        LWIP_DEBUGF(UDP_DEBUG, ("udp_send: sending datagram of length %"U16_F"\n", q->tot_len));
 
 #if LWIP_UDPLITE
-  /* UDP Lite protocol? */
-  if (pcb->flags & UDP_FLAGS_UDPLITE) {
-    u16_t chklen, chklen_hdr;
-    LWIP_DEBUGF(UDP_DEBUG, ("udp_send: UDP LITE packet length %"U16_F"\n", q->tot_len));
-    /* set UDP message length in UDP header */
-    chklen_hdr = chklen = pcb->chksum_len_tx;
-    if ((chklen < sizeof(struct udp_hdr)) || (chklen > q->tot_len)) {
-      if (chklen != 0) {
-        LWIP_DEBUGF(UDP_DEBUG, ("udp_send: UDP LITE pcb->chksum_len is illegal: %"U16_F"\n", chklen));
-      }
-      /* For UDP-Lite, checksum length of 0 means checksum
-         over the complete packet. (See RFC 3828 chap. 3.1)
-         At least the UDP-Lite header must be covered by the
-         checksum, therefore, if chksum_len has an illegal
-         value, we generate the checksum over the complete
-         packet to be safe. */
-      chklen_hdr = 0;
-      chklen = q->tot_len;
-    }
-    udphdr->len = htons(chklen_hdr);
-    /* calculate checksum */
+        /* UDP Lite protocol? */
+        if(pcb->flags & UDP_FLAGS_UDPLITE) {
+                u16_t chklen, chklen_hdr;
+                LWIP_DEBUGF(UDP_DEBUG, ("udp_send: UDP LITE packet length %"U16_F"\n", q->tot_len));
+                /* set UDP message length in UDP header */
+                chklen_hdr = chklen = pcb->chksum_len_tx;
+                if((chklen < sizeof(struct udp_hdr)) || (chklen > q->tot_len)) {
+                        if(chklen != 0) {
+                                LWIP_DEBUGF(UDP_DEBUG, ("udp_send: UDP LITE pcb->chksum_len is illegal: %"U16_F"\n", chklen));
+                        }
+                        /* For UDP-Lite, checksum length of 0 means checksum
+                           over the complete packet. (See RFC 3828 chap. 3.1)
+                           At least the UDP-Lite header must be covered by the
+                           checksum, therefore, if chksum_len has an illegal
+                           value, we generate the checksum over the complete
+                           packet to be safe. */
+                        chklen_hdr = 0;
+                        chklen = q->tot_len;
+                }
+                udphdr->len = htons(chklen_hdr);
+                /* calculate checksum */
 #if CHECKSUM_GEN_UDP
-    udphdr->chksum = inet_chksum_pseudo_partial(q, src_ip, dst_ip,
-      IP_PROTO_UDPLITE, q->tot_len,
+                udphdr->chksum = inet_chksum_pseudo_partial(q, src_ip, dst_ip,
+                        IP_PROTO_UDPLITE, q->tot_len,
 #if !LWIP_CHECKSUM_ON_COPY
-      chklen);
+                        chklen);
 #else /* !LWIP_CHECKSUM_ON_COPY */
-      (have_chksum ? UDP_HLEN : chklen));
-    if (have_chksum) {
-      u32_t acc;
-      acc = udphdr->chksum + (u16_t)~(chksum);
-      udphdr->chksum = FOLD_U32T(acc);
-    }
+                        (have_chksum ? UDP_HLEN : chklen));
+                if(have_chksum) {
+                        u32_t acc;
+                        acc = udphdr->chksum + (u16_t) ~(chksum);
+                        udphdr->chksum = FOLD_U32T(acc);
+                }
 #endif /* !LWIP_CHECKSUM_ON_COPY */
 
-    /* chksum zero must become 0xffff, as zero means 'no checksum' */
-    if (udphdr->chksum == 0x0000) {
-      udphdr->chksum = 0xffff;
-    }
+                /* chksum zero must become 0xffff, as zero means 'no checksum' */
+                if(udphdr->chksum == 0x0000) {
+                        udphdr->chksum = 0xffff;
+                }
 #endif /* CHECKSUM_GEN_UDP */
-    /* output to IP */
-    LWIP_DEBUGF(UDP_DEBUG, ("udp_send: ip_output_if (,,,,IP_PROTO_UDPLITE,)\n"));
+                /* output to IP */
+                LWIP_DEBUGF(UDP_DEBUG, ("udp_send: ip_output_if (,,,,IP_PROTO_UDPLITE,)\n"));
 #if LWIP_NETIF_HWADDRHINT
-    netif->addr_hint = &(pcb->addr_hint);
+                netif->addr_hint = &(pcb->addr_hint);
 #endif /* LWIP_NETIF_HWADDRHINT*/
-    err = ip_output_if(q, src_ip, dst_ip, pcb->ttl, pcb->tos, IP_PROTO_UDPLITE, netif);
+                err = ip_output_if(q, src_ip, dst_ip, pcb->ttl, pcb->tos, IP_PROTO_UDPLITE, netif);
 #if LWIP_NETIF_HWADDRHINT
-    netif->addr_hint = NULL;
+                netif->addr_hint = NULL;
 #endif /* LWIP_NETIF_HWADDRHINT*/
-  } else
+        } else
 #endif /* LWIP_UDPLITE */
-  {      /* UDP */
-    LWIP_DEBUGF(UDP_DEBUG, ("udp_send: UDP packet length %"U16_F"\n", q->tot_len));
-    udphdr->len = htons(q->tot_len);
-    /* calculate checksum */
+        { /* UDP */
+                LWIP_DEBUGF(UDP_DEBUG, ("udp_send: UDP packet length %"U16_F"\n", q->tot_len));
+                udphdr->len = htons(q->tot_len);
+                /* calculate checksum */
 #if CHECKSUM_GEN_UDP
-    if ((pcb->flags & UDP_FLAGS_NOCHKSUM) == 0) {
-      u16_t udpchksum;
+                if((pcb->flags & UDP_FLAGS_NOCHKSUM) == 0) {
+                        u16_t udpchksum;
 #if LWIP_CHECKSUM_ON_COPY
-      if (have_chksum) {
-        u32_t acc;
-        udpchksum = inet_chksum_pseudo_partial(q, src_ip, dst_ip, IP_PROTO_UDP,
-          q->tot_len, UDP_HLEN);
-        acc = udpchksum + (u16_t)~(chksum);
-        udpchksum = FOLD_U32T(acc);
-      } else
+                        if(have_chksum) {
+                                u32_t acc;
+                                udpchksum = inet_chksum_pseudo_partial(q, src_ip, dst_ip, IP_PROTO_UDP,
+                                        q->tot_len, UDP_HLEN);
+                                acc = udpchksum + (u16_t) ~(chksum);
+                                udpchksum = FOLD_U32T(acc);
+                        } else
 #endif /* LWIP_CHECKSUM_ON_COPY */
-      {
-        udpchksum = inet_chksum_pseudo(q, src_ip, dst_ip, IP_PROTO_UDP, q->tot_len);
-      }
+                        {
+                                udpchksum = inet_chksum_pseudo(q, src_ip, dst_ip, IP_PROTO_UDP, q->tot_len);
+                        }
 
-      /* chksum zero must become 0xffff, as zero means 'no checksum' */
-      if (udpchksum == 0x0000) {
-        udpchksum = 0xffff;
-      }
-      udphdr->chksum = udpchksum;
-    }
+                        /* chksum zero must become 0xffff, as zero means 'no checksum' */
+                        if(udpchksum == 0x0000) {
+                                udpchksum = 0xffff;
+                        }
+                        udphdr->chksum = udpchksum;
+                }
 #endif /* CHECKSUM_GEN_UDP */
-    LWIP_DEBUGF(UDP_DEBUG, ("udp_send: UDP checksum 0x%04"X16_F"\n", udphdr->chksum));
-    LWIP_DEBUGF(UDP_DEBUG, ("udp_send: ip_output_if (,,,,IP_PROTO_UDP,)\n"));
-    /* output to IP */
+                LWIP_DEBUGF(UDP_DEBUG, ("udp_send: UDP checksum 0x%04"X16_F"\n", udphdr->chksum));
+                LWIP_DEBUGF(UDP_DEBUG, ("udp_send: ip_output_if (,,,,IP_PROTO_UDP,)\n"));
+                /* output to IP */
 #if LWIP_NETIF_HWADDRHINT
-    netif->addr_hint = &(pcb->addr_hint);
+                netif->addr_hint = &(pcb->addr_hint);
 #endif /* LWIP_NETIF_HWADDRHINT*/
-    err = ip_output_if(q, src_ip, dst_ip, pcb->ttl, pcb->tos, IP_PROTO_UDP, netif);
+                err = ip_output_if(q, src_ip, dst_ip, pcb->ttl, pcb->tos, IP_PROTO_UDP, netif);
 #if LWIP_NETIF_HWADDRHINT
-    netif->addr_hint = NULL;
+                netif->addr_hint = NULL;
 #endif /* LWIP_NETIF_HWADDRHINT*/
-  }
-  /* TODO: must this be increased even if error occured? */
-  snmp_inc_udpoutdatagrams();
+        }
+        /* TODO: must this be increased even if error occured? */
+        snmp_inc_udpoutdatagrams();
 
-  /* did we chain a separate header pbuf earlier? */
-  if (q != p) {
-    /* free the header pbuf */
-    pbuf_free(q);
-    q = NULL;
-    /* p is still referenced by the caller, and will live on */
-  }
+        /* did we chain a separate header pbuf earlier? */
+        if(q != p) {
+                /* free the header pbuf */
+                pbuf_free(q);
+                q = NULL;
+                /* p is still referenced by the caller, and will live on */
+        }
 
-  UDP_STATS_INC(udp.xmit);
-  return err;
+        UDP_STATS_INC(udp.xmit);
+        return err;
 }
 
 /**
@@ -711,91 +750,89 @@ udp_sendto_if_chksum(struct udp_pcb *pcb, struct pbuf *p, ip_addr_t *dst_ip,
  * @see udp_disconnect()
  */
 err_t ICACHE_FLASH_ATTR
-udp_bind(struct udp_pcb *pcb, ip_addr_t *ipaddr, u16_t port)
-{
-  struct udp_pcb *ipcb;
-  u8_t rebind;
+udp_bind(struct udp_pcb *pcb, ip_addr_t *ipaddr, u16_t port) {
+        struct udp_pcb *ipcb;
+        u8_t rebind;
 
-  LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, ("udp_bind(ipaddr = "));
-  ip_addr_debug_print(UDP_DEBUG, ipaddr);
-  LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, (", port = %"U16_F")\n", port));
+        LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, ("udp_bind(ipaddr = "));
+        ip_addr_debug_print(UDP_DEBUG, ipaddr);
+        LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE, (", port = %"U16_F")\n", port));
 
-  rebind = 0;
-  /* Check for double bind and rebind of the same pcb */
-  for (ipcb = udp_pcbs; ipcb != NULL; ipcb = ipcb->next) {
-    /* is this UDP PCB already on active list? */
-    if (pcb == ipcb) {
-      /* pcb may occur at most once in active list */
-      LWIP_ASSERT("rebind == 0", rebind == 0);
-      /* pcb already in list, just rebind */
-      rebind = 1;
-    }
-
-    /* By default, we don't allow to bind to a port that any other udp
-       PCB is alread bound to, unless *all* PCBs with that port have tha
-       REUSEADDR flag set. */
+        rebind = 0;
+        /* Check for double bind and rebind of the same pcb */
+        for(ipcb = udp_pcbs; ipcb != NULL; ipcb = ipcb->next) {
+                /* is this UDP PCB already on active list? */
+                if(pcb == ipcb) {
+                        /* pcb may occur at most once in active list */
+                        LWIP_ASSERT("rebind == 0", rebind == 0);
+                        /* pcb already in list, just rebind */
+                        rebind = 1;
+                }/* By default, we don't allow to bind to a port that any other udp
+                           PCB is alread bound to, unless *all* PCBs with that port have tha
+                           REUSEADDR flag set. */
 #if SO_REUSE
-    else if (((pcb->so_options & SOF_REUSEADDR) == 0) &&
-             ((ipcb->so_options & SOF_REUSEADDR) == 0)) {
+                else if(((pcb->so_options & SOF_REUSEADDR) == 0) &&
+                        ((ipcb->so_options & SOF_REUSEADDR) == 0)) {
 #else /* SO_REUSE */
-    /* port matches that of PCB in list and REUSEADDR not set -> reject */
-    else {
+                        /* port matches that of PCB in list and REUSEADDR not set -> reject */
+                else {
 #endif /* SO_REUSE */
-      if ((ipcb->local_port == port) &&
-          /* IP address matches, or one is IP_ADDR_ANY? */
-          (ip_addr_isany(&(ipcb->local_ip)) ||
-           ip_addr_isany(ipaddr) ||
-           ip_addr_cmp(&(ipcb->local_ip), ipaddr))) {
-        /* other PCB already binds to this local IP and port */
-        LWIP_DEBUGF(UDP_DEBUG,
-                    ("udp_bind: local port %"U16_F" already bound by another pcb\n", port));
-        return ERR_USE;
-      }
-    }
-  }
+                        if((ipcb->local_port == port) &&
+                                /* IP address matches, or one is IP_ADDR_ANY? */
+                                (ip_addr_isany(&(ipcb->local_ip)) ||
+                                ip_addr_isany(ipaddr) ||
+                                ip_addr_cmp(&(ipcb->local_ip), ipaddr))) {
+                                /* other PCB already binds to this local IP and port */
+                                LWIP_DEBUGF(UDP_DEBUG,
+                                        ("udp_bind: local port %"U16_F" already bound by another pcb\n", port));
+                                return ERR_USE;
+                        }
+                }
+        }
 
-  ip_addr_set(&pcb->local_ip, ipaddr);
+        ip_addr_set(&pcb->local_ip, ipaddr);
 
-  /* no port specified? */
-  if (port == 0) {
+        /* no port specified? */
+        if(port == 0) {
 #ifndef UDP_LOCAL_PORT_RANGE_START
 #define UDP_LOCAL_PORT_RANGE_START 4096
 #define UDP_LOCAL_PORT_RANGE_END   0x7fff
 #endif
-    port = UDP_LOCAL_PORT_RANGE_START;
-    ipcb = udp_pcbs;
-    while ((ipcb != NULL) && (port != UDP_LOCAL_PORT_RANGE_END)) {
-      if (ipcb->local_port == port) {
-        /* port is already used by another udp_pcb */
-        port++;
-        /* restart scanning all udp pcbs */
-        ipcb = udp_pcbs;
-      } else {
-        /* go on with next udp pcb */
-        ipcb = ipcb->next;
-      }
-    }
-    if (ipcb != NULL) {
-      /* no more ports available in local range */
-      LWIP_DEBUGF(UDP_DEBUG, ("udp_bind: out of free UDP ports\n"));
-      return ERR_USE;
-    }
-  }
-  pcb->local_port = port;
-  snmp_insert_udpidx_tree(pcb);
-  /* pcb not active yet? */
-  if (rebind == 0) {
-    /* place the PCB on the active list if not already there */
-    pcb->next = udp_pcbs;
-    udp_pcbs = pcb;
-  }
-  LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_STATE,
-              ("udp_bind: bound to %"U16_F".%"U16_F".%"U16_F".%"U16_F", port %"U16_F"\n",
-               ip4_addr1_16(&pcb->local_ip), ip4_addr2_16(&pcb->local_ip),
-               ip4_addr3_16(&pcb->local_ip), ip4_addr4_16(&pcb->local_ip),
-               pcb->local_port));
-  return ERR_OK;
+                port = UDP_LOCAL_PORT_RANGE_START;
+                ipcb = udp_pcbs;
+                while((ipcb != NULL) && (port != UDP_LOCAL_PORT_RANGE_END)) {
+                        if(ipcb->local_port == port) {
+                                /* port is already used by another udp_pcb */
+                                port++;
+                                /* restart scanning all udp pcbs */
+                                ipcb = udp_pcbs;
+                        } else {
+                                /* go on with next udp pcb */
+                                ipcb = ipcb->next;
+                        }
+                }
+                if(ipcb != NULL) {
+                        /* no more ports available in local range */
+                        LWIP_DEBUGF(UDP_DEBUG, ("udp_bind: out of free UDP ports\n"));
+                        return ERR_USE;
+                }
+        }
+        pcb->local_port = port;
+        snmp_insert_udpidx_tree(pcb);
+        /* pcb not active yet? */
+        if(rebind == 0) {
+                /* place the PCB on the active list if not already there */
+                pcb->next = udp_pcbs;
+                udp_pcbs = pcb;
+        }
+        LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_STATE,
+                ("udp_bind: bound to %"U16_F".%"U16_F".%"U16_F".%"U16_F", port %"U16_F"\n",
+                ip4_addr1_16(&pcb->local_ip), ip4_addr2_16(&pcb->local_ip),
+                ip4_addr3_16(&pcb->local_ip), ip4_addr4_16(&pcb->local_ip),
+                pcb->local_port));
+        return ERR_OK;
 }
+
 /**
  * Connect an UDP PCB.
  *
@@ -814,56 +851,55 @@ udp_bind(struct udp_pcb *pcb, ip_addr_t *ipaddr, u16_t port)
  * @see udp_disconnect()
  */
 err_t ICACHE_FLASH_ATTR
-udp_connect(struct udp_pcb *pcb, ip_addr_t *ipaddr, u16_t port)
-{
-  struct udp_pcb *ipcb;
+udp_connect(struct udp_pcb *pcb, ip_addr_t *ipaddr, u16_t port) {
+        struct udp_pcb *ipcb;
 
-  if (pcb->local_port == 0) {
-    err_t err = udp_bind(pcb, &pcb->local_ip, pcb->local_port);
-    if (err != ERR_OK) {
-      return err;
-    }
-  }
+        if(pcb->local_port == 0) {
+                err_t err = udp_bind(pcb, &pcb->local_ip, pcb->local_port);
+                if(err != ERR_OK) {
+                        return err;
+                }
+        }
 
-  ip_addr_set(&pcb->remote_ip, ipaddr);
-  pcb->remote_port = port;
-  pcb->flags |= UDP_FLAGS_CONNECTED;
-/** TODO: this functionality belongs in upper layers */
+        ip_addr_set(&pcb->remote_ip, ipaddr);
+        pcb->remote_port = port;
+        pcb->flags |= UDP_FLAGS_CONNECTED;
+        /** TODO: this functionality belongs in upper layers */
 #ifdef LWIP_UDP_TODO
-  /* Nail down local IP for netconn_addr()/getsockname() */
-  if (ip_addr_isany(&pcb->local_ip) && !ip_addr_isany(&pcb->remote_ip)) {
-    struct netif *netif;
+        /* Nail down local IP for netconn_addr()/getsockname() */
+        if(ip_addr_isany(&pcb->local_ip) && !ip_addr_isany(&pcb->remote_ip)) {
+                struct netif *netif;
 
-    if ((netif = ip_route(&(pcb->remote_ip))) == NULL) {
-      LWIP_DEBUGF(UDP_DEBUG, ("udp_connect: No route to 0x%lx\n", pcb->remote_ip.addr));
-      UDP_STATS_INC(udp.rterr);
-      return ERR_RTE;
-    }
-    /** TODO: this will bind the udp pcb locally, to the interface which
-        is used to route output packets to the remote address. However, we
-        might want to accept incoming packets on any interface! */
-    pcb->local_ip = netif->ip_addr;
-  } else if (ip_addr_isany(&pcb->remote_ip)) {
-    pcb->local_ip.addr = 0;
-  }
+                if((netif = ip_route(&(pcb->remote_ip))) == NULL) {
+                        LWIP_DEBUGF(UDP_DEBUG, ("udp_connect: No route to 0x%lx\n", pcb->remote_ip.addr));
+                        UDP_STATS_INC(udp.rterr);
+                        return ERR_RTE;
+                }
+                /** TODO: this will bind the udp pcb locally, to the interface which
+                    is used to route output packets to the remote address. However, we
+                    might want to accept incoming packets on any interface! */
+                pcb->local_ip = netif->ip_addr;
+        } else if(ip_addr_isany(&pcb->remote_ip)) {
+                pcb->local_ip.addr = 0;
+        }
 #endif
-  LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_STATE,
-              ("udp_connect: connected to %"U16_F".%"U16_F".%"U16_F".%"U16_F",port %"U16_F"\n",
-               ip4_addr1_16(&pcb->local_ip), ip4_addr2_16(&pcb->local_ip),
-               ip4_addr3_16(&pcb->local_ip), ip4_addr4_16(&pcb->local_ip),
-               pcb->local_port));
+        LWIP_DEBUGF(UDP_DEBUG | LWIP_DBG_TRACE | LWIP_DBG_STATE,
+                ("udp_connect: connected to %"U16_F".%"U16_F".%"U16_F".%"U16_F",port %"U16_F"\n",
+                ip4_addr1_16(&pcb->local_ip), ip4_addr2_16(&pcb->local_ip),
+                ip4_addr3_16(&pcb->local_ip), ip4_addr4_16(&pcb->local_ip),
+                pcb->local_port));
 
-  /* Insert UDP PCB into the list of active UDP PCBs. */
-  for (ipcb = udp_pcbs; ipcb != NULL; ipcb = ipcb->next) {
-    if (pcb == ipcb) {
-      /* already on the list, just return */
-      return ERR_OK;
-    }
-  }
-  /* PCB not yet on the list, add PCB now */
-  pcb->next = udp_pcbs;
-  udp_pcbs = pcb;
-  return ERR_OK;
+        /* Insert UDP PCB into the list of active UDP PCBs. */
+        for(ipcb = udp_pcbs; ipcb != NULL; ipcb = ipcb->next) {
+                if(pcb == ipcb) {
+                        /* already on the list, just return */
+                        return ERR_OK;
+                }
+        }
+        /* PCB not yet on the list, add PCB now */
+        pcb->next = udp_pcbs;
+        udp_pcbs = pcb;
+        return ERR_OK;
 }
 
 /**
@@ -872,13 +908,12 @@ udp_connect(struct udp_pcb *pcb, ip_addr_t *ipaddr, u16_t port)
  * @param pcb the udp pcb to disconnect.
  */
 void ICACHE_FLASH_ATTR
-udp_disconnect(struct udp_pcb *pcb)
-{
-  /* reset remote address association */
-  ip_addr_set_any(&pcb->remote_ip);
-  pcb->remote_port = 0;
-  /* mark PCB as unconnected */
-  pcb->flags &= ~UDP_FLAGS_CONNECTED;
+udp_disconnect(struct udp_pcb *pcb) {
+        /* reset remote address association */
+        ip_addr_set_any(&pcb->remote_ip);
+        pcb->remote_port = 0;
+        /* mark PCB as unconnected */
+        pcb->flags &= ~UDP_FLAGS_CONNECTED;
 }
 
 /**
@@ -891,11 +926,10 @@ udp_disconnect(struct udp_pcb *pcb)
  * @param recv_arg additional argument to pass to the callback function
  */
 void ICACHE_FLASH_ATTR
-udp_recv(struct udp_pcb *pcb, udp_recv_fn recv, void *recv_arg)
-{
-  /* remember recv() callback and user data */
-  pcb->recv = recv;
-  pcb->recv_arg = recv_arg;
+udp_recv(struct udp_pcb *pcb, udp_recv_fn recv, void *recv_arg) {
+        /* remember recv() callback and user data */
+        pcb->recv = recv;
+        pcb->recv_arg = recv_arg;
 }
 
 /**
@@ -907,26 +941,25 @@ udp_recv(struct udp_pcb *pcb, udp_recv_fn recv, void *recv_arg)
  * @see udp_new()
  */
 void ICACHE_FLASH_ATTR
-udp_remove(struct udp_pcb *pcb)
-{
-  struct udp_pcb *pcb2;
+udp_remove(struct udp_pcb *pcb) {
+        struct udp_pcb *pcb2;
 
-  snmp_delete_udpidx_tree(pcb);
-  /* pcb to be removed is first in list? */
-  if (udp_pcbs == pcb) {
-    /* make list start at 2nd pcb */
-    udp_pcbs = udp_pcbs->next;
-    /* pcb not 1st in list */
-  } else {
-    for (pcb2 = udp_pcbs; pcb2 != NULL; pcb2 = pcb2->next) {
-      /* find pcb in udp_pcbs list */
-      if (pcb2->next != NULL && pcb2->next == pcb) {
-        /* remove pcb from list */
-        pcb2->next = pcb->next;
-      }
-    }
-  }
-  memp_free(MEMP_UDP_PCB, pcb);
+        snmp_delete_udpidx_tree(pcb);
+        /* pcb to be removed is first in list? */
+        if(udp_pcbs == pcb) {
+                /* make list start at 2nd pcb */
+                udp_pcbs = udp_pcbs->next;
+                /* pcb not 1st in list */
+        } else {
+                for(pcb2 = udp_pcbs; pcb2 != NULL; pcb2 = pcb2->next) {
+                        /* find pcb in udp_pcbs list */
+                        if(pcb2->next != NULL && pcb2->next == pcb) {
+                                /* remove pcb from list */
+                                pcb2->next = pcb->next;
+                        }
+                }
+        }
+        memp_free(MEMP_UDP_PCB, pcb);
 }
 
 /**
@@ -938,39 +971,38 @@ udp_remove(struct udp_pcb *pcb)
  * @see udp_remove()
  */
 struct udp_pcb * ICACHE_FLASH_ATTR
-udp_new(void)
-{
-  struct udp_pcb *pcb;
-  pcb = (struct udp_pcb *)memp_malloc(MEMP_UDP_PCB);
-  /* could allocate UDP PCB? */
-  if (pcb != NULL) {
-    /* UDP Lite: by initializing to all zeroes, chksum_len is set to 0
-     * which means checksum is generated over the whole datagram per default
-     * (recommended as default by RFC 3828). */
-    /* initialize PCB to all zeroes */
-    os_memset(pcb, 0, sizeof(struct udp_pcb));
-    pcb->ttl = UDP_TTL;
-  }
-  return pcb;
+udp_new(void) {
+        struct udp_pcb *pcb;
+        pcb = (struct udp_pcb *) memp_malloc(MEMP_UDP_PCB);
+        /* could allocate UDP PCB? */
+        if(pcb != NULL) {
+                /* UDP Lite: by initializing to all zeroes, chksum_len is set to 0
+                 * which means checksum is generated over the whole datagram per default
+                 * (recommended as default by RFC 3828). */
+                /* initialize PCB to all zeroes */
+                os_memset(pcb, 0, sizeof(struct udp_pcb));
+                pcb->ttl = UDP_TTL;
+        }
+        return pcb;
 }
 
 #if UDP_DEBUG
+
 /**
  * Print UDP header information for debug purposes.
  *
  * @param udphdr pointer to the udp header in memory.
  */
 void ICACHE_FLASH_ATTR
-udp_debug_print(struct udp_hdr *udphdr)
-{
-  LWIP_DEBUGF(UDP_DEBUG, ("UDP header:\n"));
-  LWIP_DEBUGF(UDP_DEBUG, ("+-------------------------------+\n"));
-  LWIP_DEBUGF(UDP_DEBUG, ("|     %5"U16_F"     |     %5"U16_F"     | (src port, dest port)\n",
-                          ntohs(udphdr->src), ntohs(udphdr->dest)));
-  LWIP_DEBUGF(UDP_DEBUG, ("+-------------------------------+\n"));
-  LWIP_DEBUGF(UDP_DEBUG, ("|     %5"U16_F"     |     0x%04"X16_F"    | (len, chksum)\n",
-                          ntohs(udphdr->len), ntohs(udphdr->chksum)));
-  LWIP_DEBUGF(UDP_DEBUG, ("+-------------------------------+\n"));
+udp_debug_print(struct udp_hdr *udphdr) {
+        LWIP_DEBUGF(UDP_DEBUG, ("UDP header:\n"));
+        LWIP_DEBUGF(UDP_DEBUG, ("+-------------------------------+\n"));
+        LWIP_DEBUGF(UDP_DEBUG, ("|     %5"U16_F"     |     %5"U16_F"     | (src port, dest port)\n",
+                ntohs(udphdr->src), ntohs(udphdr->dest)));
+        LWIP_DEBUGF(UDP_DEBUG, ("+-------------------------------+\n"));
+        LWIP_DEBUGF(UDP_DEBUG, ("|     %5"U16_F"     |     0x%04"X16_F"    | (len, chksum)\n",
+                ntohs(udphdr->len), ntohs(udphdr->chksum)));
+        LWIP_DEBUGF(UDP_DEBUG, ("+-------------------------------+\n"));
 }
 #endif /* UDP_DEBUG */
 

--- a/lwip/netif/espenc.c
+++ b/lwip/netif/espenc.c
@@ -11,361 +11,366 @@ static uint8_t Enc28j60Bank;
 static uint16_t NextPacketPtr;
 
 void ICACHE_FLASH_ATTR chipEnable() {
-    // Force CS pin low (FIXME)
-    PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTDO_U, FUNC_GPIO15);
-    GPIO_OUTPUT_SET(ESP_CS, 0);
+        // Force CS pin low (FIXME)
+        PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTDO_U, FUNC_GPIO15);
+        GPIO_OUTPUT_SET(ESP_CS, 0);
 }
 
 void ICACHE_FLASH_ATTR chipDisable() {
-    // Return to default CS function
-    PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTDO_U, 2); //GPIO15 is HSPI CS pin (Chip Select / Slave Select)
+        // Return to default CS function
+        PIN_FUNC_SELECT(PERIPHS_IO_MUX_MTDO_U, 2); //GPIO15 is HSPI CS pin (Chip Select / Slave Select)
 }
 
-
 uint8_t readOp(uint8_t op, uint8_t addr) {
-    if(addr & 0x80)
-        return (uint8_t) spi_transaction(HSPI, 3, op >> 5, 5, addr, 0, 0, 16, 0) & 0xff; // Ignore dummy first byte
-    else
-        return (uint8_t) spi_transaction(HSPI, 3, op >> 5, 5, addr, 0, 0, 8, 0);
+        if(addr & 0x80)
+                return(uint8_t) spi_transaction(HSPI, 3, op >> 5, 5, addr, 0, 0, 16, 0) & 0xff; // Ignore dummy first byte
+        else
+                return(uint8_t) spi_transaction(HSPI, 3, op >> 5, 5, addr, 0, 0, 8, 0);
 }
 
 void writeOp(uint8_t op, uint8_t addr, uint8_t data) {
-    spi_transaction(HSPI, 3, op >> 5, 5, addr, 8, data, 0, 0);
+        spi_transaction(HSPI, 3, op >> 5, 5, addr, 8, data, 0, 0);
 }
 
-static void SetBank (uint8_t address) {
-    if ((address & BANK_MASK) != Enc28j60Bank) {
-        writeOp(ENC28J60_BIT_FIELD_CLR, ECON1, ECON1_BSEL1|ECON1_BSEL0);
-        Enc28j60Bank = address & BANK_MASK;
-        writeOp(ENC28J60_BIT_FIELD_SET, ECON1, Enc28j60Bank>>5);
-    }
+static void SetBank(uint8_t address) {
+        if((address & BANK_MASK) != Enc28j60Bank) {
+                writeOp(ENC28J60_BIT_FIELD_CLR, ECON1, ECON1_BSEL1 | ECON1_BSEL0);
+                Enc28j60Bank = address & BANK_MASK;
+                writeOp(ENC28J60_BIT_FIELD_SET, ECON1, Enc28j60Bank >> 5);
+        }
 }
 
-static uint8_t readRegByte (uint8_t address) {
-    SetBank(address);
-    return readOp(ENC28J60_READ_CTRL_REG, address);
+static uint8_t readRegByte(uint8_t address) {
+        SetBank(address);
+        return readOp(ENC28J60_READ_CTRL_REG, address);
 }
 
 static uint16_t readReg(uint8_t address) {
-    return readRegByte(address) + (readRegByte(address+1) << 8);
+        return readRegByte(address) + (readRegByte(address + 1) << 8);
 }
 
-static void writeRegByte (uint8_t address, uint8_t data) {
-    SetBank(address);
-    writeOp(ENC28J60_WRITE_CTRL_REG, address, data);
+static void writeRegByte(uint8_t address, uint8_t data) {
+        SetBank(address);
+        writeOp(ENC28J60_WRITE_CTRL_REG, address, data);
 }
 
 static void writeReg(uint8_t address, uint16_t data) {
-    writeRegByte(address, data);
-    writeRegByte(address + 1, data >> 8);
+        writeRegByte(address, data);
+        writeRegByte(address + 1, data >> 8);
 }
 
-static uint16_t readPhyByte (uint8_t address) {
-    writeRegByte(MIREGADR, address);
-    writeRegByte(MICMD, MICMD_MIIRD);
-    while (readRegByte(MISTAT) & MISTAT_BUSY)
-        ;
-    writeRegByte(MICMD, 0x00);
-    return readRegByte(MIRD+1);
+static uint16_t readPhyByte(uint8_t address) {
+        writeRegByte(MIREGADR, address);
+        writeRegByte(MICMD, MICMD_MIIRD);
+        while(readRegByte(MISTAT) & MISTAT_BUSY)
+                ;
+        writeRegByte(MICMD, 0x00);
+        return readRegByte(MIRD + 1);
 }
 
-static void writePhy (uint8_t address, uint16_t data) {
-    writeRegByte(MIREGADR, address);
-    writeReg(MIWR, data);
-    while (readRegByte(MISTAT) & MISTAT_BUSY)
-        ;
+static void writePhy(uint8_t address, uint16_t data) {
+        writeRegByte(MIREGADR, address);
+        writeReg(MIWR, data);
+        while(readRegByte(MISTAT) & MISTAT_BUSY)
+                ;
 }
 
 static void readBuf(uint16_t len, uint8_t* data) {
-    // force CS pin here, as it requires multiple bytes to be sent
-    log("readBuf()");
-    chipEnable();
-    if (len != 0) {
-        spi_transaction(HSPI, 8, ENC28J60_READ_BUF_MEM, 0, 0, 0, 0, 0, 0);
-        while (len--) {
-            uint8_t nextbyte;
+        // force CS pin here, as it requires multiple bytes to be sent
+        log("readBuf()");
+        chipEnable();
+        if(len != 0) {
+                spi_transaction(HSPI, 8, ENC28J60_READ_BUF_MEM, 0, 0, 0, 0, 0, 0);
+                while(len--) {
+                        uint8_t nextbyte;
 
-            while(spi_busy(HSPI));	//wait for SPI transaction to complete
-            nextbyte = spi_transaction(HSPI, 0, 0, 0, 0, 0, 0, 8, 0);
-            *data++ = nextbyte;
-     	};
-        while(spi_busy(HSPI));	//wait for SPI transaction to complete
-    }
-    chipDisable();
+                        while(spi_busy(HSPI)); //wait for SPI transaction to complete
+                        nextbyte = spi_transaction(HSPI, 0, 0, 0, 0, 0, 0, 8, 0);
+                        *data++ = nextbyte;
+                };
+                while(spi_busy(HSPI)); //wait for SPI transaction to complete
+        }
+        chipDisable();
 }
 
 static void writeBuf(uint16_t len, const uint8_t* data) {
-    // force CS pin here, as it requires multiple bytes to be sent
-    chipEnable();
-    if (len != 0) {
-        spi_transaction(HSPI, 8, ENC28J60_WRITE_BUF_MEM, 0, 0, 8, 0, 0, 0);
-        while (len--) {
-            uint8_t nextbyte = *data++;
+        // force CS pin here, as it requires multiple bytes to be sent
+        chipEnable();
+        if(len != 0) {
+                spi_transaction(HSPI, 8, ENC28J60_WRITE_BUF_MEM, 0, 0, 8, 0, 0, 0);
+                while(len--) {
+                        uint8_t nextbyte = *data++;
 
-            while(spi_busy(HSPI));	//wait for SPI transaction to complete
-            spi_transaction(HSPI, 0, 0, 0, 0, 8, nextbyte, 0, 0);
-     	};
-        while(spi_busy(HSPI));	//wait for SPI transaction to complete
-    }
-    chipDisable();
+                        while(spi_busy(HSPI)); //wait for SPI transaction to complete
+                        spi_transaction(HSPI, 0, 0, 0, 0, 8, nextbyte, 0, 0);
+                };
+                while(spi_busy(HSPI)); //wait for SPI transaction to complete
+        }
+        chipDisable();
 }
 
 uint8_t ICACHE_FLASH_ATTR enc28j60_int_disable() {
-    uint8_t interrupts = 0;
-    SetBank(EIE);
-    interrupts = readRegByte(EIE);
-    writeOp(ENC28J60_BIT_FIELD_CLR, EIE, interrupts);
-    return interrupts;
+        uint8_t interrupts = 0;
+        SetBank(EIE);
+        interrupts = readRegByte(EIE);
+        writeOp(ENC28J60_BIT_FIELD_CLR, EIE, interrupts);
+        return interrupts;
 }
 
 void ICACHE_FLASH_ATTR enc28j60_int_enable(uint8_t interrupts) {
-    SetBank(EIE);
-    writeOp(ENC28J60_BIT_FIELD_SET, EIE, interrupts);
+        SetBank(EIE);
+        writeOp(ENC28J60_BIT_FIELD_SET, EIE, interrupts);
 }
 
 err_t ICACHE_FLASH_ATTR enc28j60_link_output(struct netif *netif, struct pbuf *p) {
-    uint8_t retry = 0;
-    uint16_t len = p->tot_len;
+        uint8_t retry = 0;
+        uint16_t len = p->tot_len;
 
-    uint8_t interrupts = enc28j60_int_disable();
+        uint8_t interrupts = enc28j60_int_disable();
 
-    log("output, tot_len: %d", p->tot_len);
-    uint8_t isUp = (readPhyByte(PHSTAT2) >> 2) & 1;
-    log("link is up: %d", isUp);
-    log("pktcnt: %d", readRegByte(EPKTCNT));
+        log("output, tot_len: %d", p->tot_len);
+        uint8_t isUp = (readPhyByte(PHSTAT2) >> 2) & 1;
+        log("link is up: %d", isUp);
+        log("pktcnt: %d", readRegByte(EPKTCNT));
 
-    SetBank(ECON1);
-    writeOp(ENC28J60_BIT_FIELD_SET, ECON1, ECON1_TXRST);
-    writeOp(ENC28J60_BIT_FIELD_CLR, ECON1, ECON1_TXRST);
-    SetBank(EIR);
-    writeOp(ENC28J60_BIT_FIELD_CLR, EIR, EIR_TXERIF|EIR_TXIF);
+        SetBank(ECON1);
+        writeOp(ENC28J60_BIT_FIELD_SET, ECON1, ECON1_TXRST);
+        writeOp(ENC28J60_BIT_FIELD_CLR, ECON1, ECON1_TXRST);
+        SetBank(EIR);
+        writeOp(ENC28J60_BIT_FIELD_CLR, EIR, EIR_TXERIF | EIR_TXIF);
 
-    if(retry == 0) {
-        writeReg(EWRPT, TXSTART_INIT);
-        writeReg(ETXND, TXSTART_INIT+len);
-        //writeOp(ENC28J60_WRITE_BUF_MEM, 0, 0x00);
-        uint8_t* buffer = (uint8_t*) os_malloc(len);
-        pbuf_copy_partial(p, buffer, p->tot_len, 0);
-        writeBuf(len, buffer);
-        os_free(buffer);
-    }
+        if(retry == 0) {
+                writeReg(EWRPT, TXSTART_INIT);
+                writeReg(ETXND, TXSTART_INIT + len);
+                //writeOp(ENC28J60_WRITE_BUF_MEM, 0, 0x00);
+                uint8_t* buffer = (uint8_t*) os_malloc(len);
+                pbuf_copy_partial(p, buffer, p->tot_len, 0);
+                writeBuf(len, buffer);
+                os_free(buffer);
+        }
 
-    SetBank(EIR);
-    writeOp(ENC28J60_BIT_FIELD_CLR, EIR, EIR_TXERIF|EIR_TXIF);
-    log("before transmission: %02x", readRegByte(EIR));
-    SetBank(ECON1);
-    writeOp(ENC28J60_BIT_FIELD_SET, ECON1, ECON1_TXRTS);
+        SetBank(EIR);
+        writeOp(ENC28J60_BIT_FIELD_CLR, EIR, EIR_TXERIF | EIR_TXIF);
+        log("before transmission: %02x", readRegByte(EIR));
+        SetBank(ECON1);
+        writeOp(ENC28J60_BIT_FIELD_SET, ECON1, ECON1_TXRTS);
 
-    uint16_t count = 0;
-    uint16_t eir = 0;
-    while (((eir = readRegByte(EIR)) & (EIR_TXIF | EIR_TXERIF)) == 0 && ++count < 1000U)
-        ;
+        uint16_t count = 0;
+        uint16_t eir = 0;
+        while(((eir = readRegByte(EIR)) & (EIR_TXIF | EIR_TXERIF)) == 0 && ++count < 1000U)
+                ;
 
-    if (!(eir & EIR_TXERIF) && count < 1000U) {
-        // no error; start new transmission
-        log("transmission success");
-    } else {
-        log("transmission failed (%d - %02x)", count, eir);
-    }
+        if(!(eir & EIR_TXERIF) && count < 1000U) {
+                // no error; start new transmission
+                log("transmission success");
+        } else {
+                log("transmission failed (%d - %02x)", count, eir);
+        }
 
-    SetBank(ECON1);
-    writeOp(ENC28J60_BIT_FIELD_CLR, ECON1, ECON1_TXRTS);
+        SetBank(ECON1);
+        writeOp(ENC28J60_BIT_FIELD_CLR, ECON1, ECON1_TXRTS);
 
-    enc28j60_int_enable(interrupts);
+        enc28j60_int_enable(interrupts);
 }
 
 static uint32_t interrupt_reg = 0;
 
 void enc28j60_handle_packets(void) {
-    log("reading ptr: %04x", NextPacketPtr);
-    writeReg(ERDPT, NextPacketPtr);
-    uint16_t packetLen = 0;
-    uint16_t rxStatus = 0;
+        log("reading ptr: %04x", NextPacketPtr);
+        writeReg(ERDPT, NextPacketPtr);
+        uint16_t packetLen = 0;
+        uint16_t rxStatus = 0;
 
-    readBuf(2, (uint8_t*) &NextPacketPtr);
-    readBuf(2, (uint8_t*) &packetLen);
-    readBuf(2, (uint8_t*) &rxStatus);
+        readBuf(2, (uint8_t*) & NextPacketPtr);
+        readBuf(2, (uint8_t*) & packetLen);
+        readBuf(2, (uint8_t*) & rxStatus);
 
-    // Ignore packet checksum TODO
-    packetLen -= 4;
+        // Ignore packet checksum TODO
+        packetLen -= 4;
 
-    log("next ptr: %04x", NextPacketPtr);
-    log("packet len: %d (%x)", packetLen, packetLen);
-    log("rx status: %02x", rxStatus);
+        log("next ptr: %04x", NextPacketPtr);
+        log("packet len: %d (%x)", packetLen, packetLen);
+        log("rx status: %02x", rxStatus);
 
-    if(rxStatus & 0x80 == 0) {
-        log("RECEIVE FAILED");
-    } else {
-        uint16_t len = packetLen;
-        struct pbuf* p = pbuf_alloc(PBUF_LINK, len, PBUF_RAM);
-        if(p != 0) {
-            uint8_t* data;
-            struct pbuf* q;
-
-            for(q = p; q != 0; q= q->next) {
-                data = q->payload;
-                len = q->len;
-
-                log("reading %d to %x", len, data);
-                readBuf(len, data);
-            }
-
-            log("packet received, passing to netif->input");
-            enc_netif.input(p, &enc_netif);
+        if(rxStatus & 0x80 == 0) {
+                log("RECEIVE FAILED");
         } else {
-            log("pbuf_alloc failed!");
+                uint16_t len = packetLen;
+                struct pbuf* p = pbuf_alloc(PBUF_LINK, len, PBUF_RAM);
+                if(p != 0) {
+                        uint8_t* data;
+                        struct pbuf* q;
+
+                        for(q = p; q != 0; q = q->next) {
+                                data = q->payload;
+                                len = q->len;
+
+                                log("reading %d to %x", len, data);
+                                readBuf(len, data);
+                        }
+
+                        log("packet received, passing to netif->input");
+                        enc_netif.input(p, &enc_netif);
+                } else {
+                        log("pbuf_alloc failed!");
+                }
         }
-    }
 
-    SetBank(ECON2);
-    writeOp(ENC28J60_BIT_FIELD_SET, ECON2, ECON2_PKTDEC);
+        SetBank(ECON2);
+        writeOp(ENC28J60_BIT_FIELD_SET, ECON2, ECON2_PKTDEC);
 
-    writeReg(ERXRDPT, NextPacketPtr);
+        writeReg(ERXRDPT, NextPacketPtr);
 }
 
 void interrupt_handler(void *arg) {
-    ETS_GPIO_INTR_DISABLE();
-    GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, GPIO_REG_READ(GPIO_STATUS_ADDRESS));
+        ETS_GPIO_INTR_DISABLE();
+        GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, GPIO_REG_READ(GPIO_STATUS_ADDRESS));
 
-    uint8_t interrupt = readRegByte(EIR);
-    uint8_t pktCnt = readRegByte(EPKTCNT);
+        uint8_t interrupt = readRegByte(EIR);
+        uint8_t pktCnt = readRegByte(EPKTCNT);
 
-    log(" *** INTERRUPT (%02X / %d) ***", interrupt, pktCnt);
+        log(" *** INTERRUPT (%02X / %d) ***", interrupt, pktCnt);
 
-    if(pktCnt > 0) {
-        log("pktCnt > 0");
+        if(pktCnt > 0) {
+                log("pktCnt > 0");
 
-        while(readRegByte(EPKTCNT) > 0)
-            enc28j60_handle_packets();
+                while(readRegByte(EPKTCNT) > 0)
+                        enc28j60_handle_packets();
 
-        //SetBank(EIE);
-        //writeOp(ENC28J60_BIT_FIELD_CLR, EIE, EIE_PKTIE);
-    }
+                //SetBank(EIE);
+                //writeOp(ENC28J60_BIT_FIELD_CLR, EIE, EIE_PKTIE);
+        }
 
-    if(interrupt & EIR_PKTIF) {
-        log("PKTIF interrupt");
-        SetBank(EIR);
-        writeOp(ENC28J60_BIT_FIELD_CLR, EIR, EIR_PKTIF);
-    }
+        if(interrupt & EIR_PKTIF) {
+                log("PKTIF interrupt");
+                SetBank(EIR);
+                writeOp(ENC28J60_BIT_FIELD_CLR, EIR, EIR_PKTIF);
+        }
 
-    if(interrupt & EIR_TXIF) {
-        log("TXIF interrupt");
+        if(interrupt & EIR_TXIF) {
+                log("TXIF interrupt");
 
-        SetBank(EIR);
-        writeOp(ENC28J60_BIT_FIELD_CLR, EIR, EIR_TXIF);
-    }
+                SetBank(EIR);
+                writeOp(ENC28J60_BIT_FIELD_CLR, EIR, EIR_TXIF);
+        }
 
-    if(interrupt & EIR_TXERIF) {
-        log("TXERIF int");
-        SetBank(EIR);
-        writeOp(ENC28J60_BIT_FIELD_CLR, EIR, EIR_TXERIF);
-    }
+        if(interrupt & EIR_TXERIF) {
+                log("TXERIF int");
+                SetBank(EIR);
+                writeOp(ENC28J60_BIT_FIELD_CLR, EIR, EIR_TXERIF);
+        }
 
-    ETS_GPIO_INTR_ENABLE();
+        ETS_GPIO_INTR_ENABLE();
 }
 
 // http://lwip.wikia.com/wiki/Writing_a_device_driver
+
 err_t ICACHE_FLASH_ATTR enc28j60_init(struct netif *netif) {
-    ETS_GPIO_INTR_ATTACH(interrupt_handler, &interrupt_reg);
-    ETS_GPIO_INTR_ENABLE();
+        ETS_GPIO_INTR_ATTACH(interrupt_handler, &interrupt_reg);
+        ETS_GPIO_INTR_ENABLE();
 
-    gpio_register_set(GPIO_PIN_ADDR(ESP_INT), GPIO_PIN_INT_TYPE_SET(GPIO_PIN_INTR_DISABLE)
-            | GPIO_PIN_PAD_DRIVER_SET(GPIO_PAD_DRIVER_DISABLE)
-            | GPIO_PIN_SOURCE_SET(GPIO_AS_PIN_SOURCE));
+        gpio_register_set(GPIO_PIN_ADDR(ESP_INT), GPIO_PIN_INT_TYPE_SET(GPIO_PIN_INTR_DISABLE)
+                | GPIO_PIN_PAD_DRIVER_SET(GPIO_PAD_DRIVER_DISABLE)
+                | GPIO_PIN_SOURCE_SET(GPIO_AS_PIN_SOURCE));
 
-    GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, 1 << ESP_INT);
-    gpio_pin_intr_state_set(GPIO_ID_PIN(ESP_INT), GPIO_PIN_INTR_NEGEDGE);
+        GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, 1 << ESP_INT);
+        gpio_pin_intr_state_set(GPIO_ID_PIN(ESP_INT), GPIO_PIN_INTR_NEGEDGE);
 
-    log("interrupts enabled");
+        log("interrupts enabled");
 
-    log("initializing");
-    netif->linkoutput = enc28j60_link_output;
-    netif->name[0] = 'e';
-    netif->name[1] = 'n';
-    netif->mtu = 1500;
-    netif->hwaddr_len = 6;
-    //netif->hwaddr[0] = 0x00;
-    //netif->hwaddr[1] = 0x11;
-    //netif->hwaddr[2] = 0x22;
-    //netif->hwaddr[3] = 0x33;
-    //netif->hwaddr[4] = 0x44;
-    //netif->hwaddr[5] = 0x55;
+        log("initializing");
+        netif->linkoutput = enc28j60_link_output;
+        netif->name[0] = 'e';
+        netif->name[1] = 'n';
+        netif->mtu = 1500;
+        netif->hwaddr_len = 6;
 
-    netif->output = etharp_output;
-    netif->flags |= NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP;
+        netif->output = etharp_output;
+        netif->flags |= NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP;
 
-    log("initializing hardware");
-    spi_init(HSPI);
-    spi_mode(HSPI, 0, 0);
+        log("initializing hardware");
+        spi_init(HSPI);
+        spi_mode(HSPI, 0, 0);
 
-    writeOp(ENC28J60_SOFT_RESET, 0, ENC28J60_SOFT_RESET);
-    uint8_t estat;
-    while(!(estat = readOp(ENC28J60_READ_CTRL_REG, ESTAT)) & ESTAT_CLKRDY) {
-        log("estat: %02x", estat);
+        writeOp(ENC28J60_SOFT_RESET, 0, ENC28J60_SOFT_RESET);
         os_delay_us(2000); // errata B7/2
-    }
-    NextPacketPtr = RXSTART_INIT;
-    writeReg(ERXST, RXSTART_INIT);
-    writeReg(ERXRDPT, RXSTART_INIT);
-    writeReg(ERXND, RXSTOP_INIT);
-    writeReg(ETXST, TXSTART_INIT);
-    writeReg(ETXND, TXSTOP_INIT);
+        uint8_t estat;
+        while(!(estat = readOp(ENC28J60_READ_CTRL_REG, ESTAT)) & ESTAT_CLKRDY) {
+                log("estat: %02x", estat);
+        }
+        NextPacketPtr = RXSTART_INIT;
+        writeReg(ERXST, RXSTART_INIT);
+        writeReg(ERXRDPT, RXSTART_INIT);
+        writeReg(ERXND, RXSTOP_INIT);
+        writeReg(ETXST, TXSTART_INIT);
+        writeReg(ETXND, TXSTOP_INIT);
 
-    writeRegByte(ERXFCON, ERXFCON_UCEN|ERXFCON_CRCEN|ERXFCON_PMEN|ERXFCON_BCEN);
-    writeReg(EPMM0, 0x303f);
-    writeReg(EPMCS, 0xf7f9);
-    writeRegByte(MACON1, MACON1_MARXEN|MACON1_TXPAUS|MACON1_RXPAUS);
-    writeRegByte(MACON2, 0x00);
-    writeOp(ENC28J60_BIT_FIELD_SET, MACON3,
-            MACON3_PADCFG0|MACON3_TXCRCEN|MACON3_FRMLNEN);
-    writeReg(MAIPG, 0x0C12);
-    writeRegByte(MABBIPG, 0x12);
-    writeReg(MAMXFL, MAX_FRAMELEN);
-    writeRegByte(MAADR5, netif->hwaddr[0]);
-    writeRegByte(MAADR4, netif->hwaddr[1]);
-    writeRegByte(MAADR3, netif->hwaddr[2]);
-    writeRegByte(MAADR2, netif->hwaddr[3]);
-    writeRegByte(MAADR1, netif->hwaddr[4]);
-    writeRegByte(MAADR0, netif->hwaddr[5]);
-    writePhy(PHCON2, PHCON2_HDLDIS);
-    SetBank(EIE);
-    writeOp(ENC28J60_BIT_FIELD_SET, EIE, EIE_INTIE|EIE_PKTIE);
+        writeRegByte(ERXFCON, ERXFCON_UCEN | ERXFCON_CRCEN | ERXFCON_PMEN | ERXFCON_BCEN);
+        writeReg(EPMM0, 0x303f);
+        writeReg(EPMCS, 0xf7f9);
+        writeRegByte(MACON1, MACON1_MARXEN | MACON1_TXPAUS | MACON1_RXPAUS);
+        writeRegByte(MACON2, 0x00);
+        writeOp(ENC28J60_BIT_FIELD_SET, MACON3,
+                MACON3_PADCFG0 | MACON3_TXCRCEN | MACON3_FRMLNEN);
+        writeReg(MAIPG, 0x0C12);
+        writeRegByte(MABBIPG, 0x12);
+        writeReg(MAMXFL, MAX_FRAMELEN);
+        writeRegByte(MAADR5, netif->hwaddr[0]);
+        writeRegByte(MAADR4, netif->hwaddr[1]);
+        writeRegByte(MAADR3, netif->hwaddr[2]);
+        writeRegByte(MAADR2, netif->hwaddr[3]);
+        writeRegByte(MAADR1, netif->hwaddr[4]);
+        writeRegByte(MAADR0, netif->hwaddr[5]);
 
-    SetBank(EIR);
-    writeOp(ENC28J60_BIT_FIELD_CLR, EIR, EIR_PKTIF);
+        // Force soft reset PHY.
+        // Sometimes the SPI reset does not reset it,
+        // or it is not actually ready yet.
+        // I'm unsure which is the actual case, but this solves
+        // a problem that occurs for me, where the PHY never seems
+        // to be able to receive packets. --AJK
+        writePhy(PHCON1, PHCON1_PRST);
+        while(!(estat = readPhyByte(PHCON1)) & PHCON1_PRST) {
+                log("Phy reset stat: %02x", estat);
+        }
+        writePhy(PHCON2, PHCON2_HDLDIS);
+        SetBank(EIE);
+        writeOp(ENC28J60_BIT_FIELD_SET, EIE, EIE_INTIE | EIE_PKTIE);
 
-    SetBank(ECON1);
-    writeOp(ENC28J60_BIT_FIELD_SET, ECON1, ECON1_RXEN);
+        SetBank(EIR);
+        writeOp(ENC28J60_BIT_FIELD_CLR, EIR, EIR_PKTIF);
 
-    uint8_t rev = readRegByte(EREVID);
-    // microchip forgot to step the number on the silcon when they
-    // released the revision B7. 6 is now rev B7. We still have
-    // to see what they do when they release B8. At the moment
-    // there is no B8 out yet
-    if (rev > 5) ++rev;
-    log("hardware ready, rev: %d", rev);
+        SetBank(ECON1);
+        writeOp(ENC28J60_BIT_FIELD_SET, ECON1, ECON1_RXEN);
 
-    return ERR_OK;
+        uint8_t rev = readRegByte(EREVID);
+        // microchip forgot to step the number on the silcon when they
+        // released the revision B7. 6 is now rev B7. We still have
+        // to see what they do when they release B8. At the moment
+        // there is no B8 out yet
+        if(rev > 5) ++rev;
+        log("hardware ready, rev: %d", rev);
+
+        return ERR_OK;
 }
 
 struct netif* ICACHE_FLASH_ATTR espenc_init(uint8_t *mac_addr, ip_addr_t *ip, ip_addr_t *mask, ip_addr_t *gw, bool dhcp) {
-    ip_addr_t nulladdr;
-    struct netif* new_netif;
+        ip_addr_t nulladdr;
+        struct netif* new_netif;
 
-    IP4_ADDR(&nulladdr, 0, 0, 0, 0);
-    
-    os_memcpy (enc_netif.hwaddr, mac_addr, 6);
+        IP4_ADDR(&nulladdr, 0, 0, 0, 0);
 
-    if (dhcp) {
-	new_netif = netif_add(&enc_netif, &nulladdr, &nulladdr, &nulladdr, NULL, enc28j60_init, ethernet_input);
-	if (new_netif) {
-	    dhcp_start(new_netif);
-	}
-    } else {
-	new_netif = netif_add(&enc_netif, ip, mask, gw, NULL, enc28j60_init, ethernet_input);
-	if (new_netif) {
-	    netif_set_up(new_netif);
-	}
-    }
-    return new_netif;
+        os_memcpy(enc_netif.hwaddr, mac_addr, 6);
+
+        if(dhcp) {
+                new_netif = netif_add(&enc_netif, &nulladdr, &nulladdr, &nulladdr, NULL, enc28j60_init, ethernet_input);
+                if(new_netif) {
+                        dhcp_start(new_netif);
+                }
+        } else {
+                new_netif = netif_add(&enc_netif, ip, mask, gw, NULL, enc28j60_init, ethernet_input);
+                if(new_netif) {
+                        netif_set_up(new_netif);
+                }
+        }
+        return new_netif;
 }


### PR DESCRIPTION
Fix UDP route bug for broadcasts.
Fix IP route bug to direct packets to correct interface.
Fix ENC28J60 code to reset the PHY during init phase.
Split and recycle dhcpserver.h to reduce source bloat.
Add DHCP server for ENC28J60.
Removed trailing whitespace on all changed files.
Reformat indent as needed on all changed files.