### PR TITLE
Multiple fixes

### DIFF
--- a/fastmake.sh
+++ b/fastmake.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+make -f Makefile.open clean
+make -f Makefile.open COMPILE=gcc BOOT=none APP=0 SPI_SPEED=40 SPI_MODE=QIO SPI_SIZE_MAP=0

--- a/include/lwip/icmp.h
+++ b/include/lwip/icmp.h
@@ -105,7 +105,9 @@ PACK_STRUCT_END
 void icmp_input(struct pbuf *p, struct netif *inp)ICACHE_FLASH_ATTR;
 void icmp_dest_unreach(struct pbuf *p, enum icmp_dur_type t)ICACHE_FLASH_ATTR;
 void icmp_time_exceeded(struct pbuf *p, enum icmp_te_type t)ICACHE_FLASH_ATTR;
-
+#if IP_FORWARD
+void icmp_datagram_too_big(struct pbuf *p, u16_t mtu)ICACHE_FLASH_ATTR;
+#endif /* IP_FORWARD */
 #endif /* LWIP_ICMP */
 
 #ifdef __cplusplus

--- a/include/netif/espenc.h
+++ b/include/netif/espenc.h
@@ -226,7 +226,7 @@ struct netif* espenc_init(uint8_t *mac_addr, ip_addr_t *ip, ip_addr_t *mask, ip_
 
 // max frame length which the controller will accept:
 // (note: maximum ethernet frame length would be 1518)
-#define MAX_FRAMELEN      1500
+#define MAX_FRAMELEN      1518
 
 #define FULL_SPEED  1   // switch to full-speed SPI for bulk transfers
 

--- a/lwip/app/espconn.c
+++ b/lwip/app/espconn.c
@@ -449,7 +449,7 @@ espconn_sendto(struct espconn *espconn, uint8 *psent, uint16 length)
 {
 	espconn_msg *pnode = NULL;
 	bool value = false;
-	err_t error = ESPCONN_OK;
+	//err_t error = ESPCONN_OK;
 
 	if (espconn == NULL || psent == NULL || length == 0) {
 		return ESPCONN_ARG;

--- a/lwip/core/ipv4/ip.c
+++ b/lwip/core/ipv4/ip.c
@@ -1020,6 +1020,14 @@ ip_forward(struct pbuf *p, struct ip_hdr *iphdr, struct netif *inp)
   snmp_inc_ipforwdatagrams();
 
   PERF_STOP("ip_forward");
+  /* check MTU, see RFC 1191 */
+  u16_t dif = netif->mtu;
+  //os_printf("ip_forward: checking mtu %c%c %d < %d\r\n", netif->name[0], netif->name[1], dif, p->tot_len);
+  if(dif < p->tot_len) {
+          //os_printf("ip_forward: datagram too big for %c%c %d, %d -> %d\r\n", netif->name[0], netif->name[1], netif->mtu, p->tot_len, dif);
+          icmp_datagram_too_big(p, dif);
+          return;
+  }
   /* transmit pbuf on chosen interface */
   netif->output(netif, p, &current_iphdr_dest);
   return;

--- a/lwip/netif/espenc.c
+++ b/lwip/netif/espenc.c
@@ -125,11 +125,9 @@ void ICACHE_FLASH_ATTR enc28j60_int_enable(uint8_t interrupts) {
 }
 
 err_t ICACHE_FLASH_ATTR enc28j60_link_output(struct netif *netif, struct pbuf *p) {
-        uint8_t retry = 0;
         uint16_t len = p->tot_len;
 
         uint8_t interrupts = enc28j60_int_disable();
-
         log("output, tot_len: %d", p->tot_len);
         uint8_t isUp = (readPhyByte(PHSTAT2) >> 2) & 1;
         log("link is up: %d", isUp);
@@ -141,15 +139,13 @@ err_t ICACHE_FLASH_ATTR enc28j60_link_output(struct netif *netif, struct pbuf *p
         SetBank(EIR);
         writeOp(ENC28J60_BIT_FIELD_CLR, EIR, EIR_TXERIF | EIR_TXIF);
 
-        if(retry == 0) {
-                writeReg(EWRPT, TXSTART_INIT);
-                writeReg(ETXND, TXSTART_INIT + len);
-                //writeOp(ENC28J60_WRITE_BUF_MEM, 0, 0x00);
-                uint8_t* buffer = (uint8_t*) os_malloc(len);
-                pbuf_copy_partial(p, buffer, p->tot_len, 0);
-                writeBuf(len, buffer);
-                os_free(buffer);
-        }
+        writeReg(EWRPT, TXSTART_INIT);
+        writeReg(ETXND, TXSTART_INIT + len);
+        //writeOp(ENC28J60_WRITE_BUF_MEM, 0, 0x00);
+        uint8_t* buffer = (uint8_t*) os_malloc(len);
+        pbuf_copy_partial(p, buffer, p->tot_len, 0);
+        writeBuf(len, buffer);
+        os_free(buffer);
 
         SetBank(EIR);
         writeOp(ENC28J60_BIT_FIELD_CLR, EIR, EIR_TXERIF | EIR_TXIF);


### PR DESCRIPTION
This Merge request includes the following:
Add RFC 1191 compliance for forwarding packets.
Correct MAX_FRAMELEN, which was not set correctly.
Remove dead code and unused conditional .
Add a script to quickly compile with some predefined options.

All that seems to be left is to find out why WiFi interface dies when heavy traffic forwards to/from the enc28j60 interface. Once that is done I would consider it no longer experimental.