### PR TITLE
Fix so that the code actually does the data scoop. Prevents NPE.

### DIFF
--- a/lwip/netif/espenc.c
+++ b/lwip/netif/espenc.c
@@ -342,7 +342,7 @@ void interrupt_handler(void *arg) {
 
                 if(pktCnt > 0 && (interrupt & EIR_PKTIF)) {
                         log("pktCnt > 0");
-#if ENC_SCOOPS
+#if 1
        // ACK interrupt
                         GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, gpio_status & BIT(ESP_INT));
 


### PR DESCRIPTION
Typical 1 line fix.
[00:19:29] 106173 KiB in	 75696 KiB out	115072 B/s in	  4212 B/s out	 55688 free heap
Nice thruput.