### PR TITLE
ipv4: napt: use new LWIP_TIME_DIFF macro when comparing time.

### DIFF
--- a/include/lwip/sys.h
+++ b/include/lwip/sys.h
@@ -237,6 +237,10 @@ static inline u32_t sys_now(void)
 	return NOW()/(TIMER_CLK_FREQ/1000);
 }
 
+/** Get the absolute difference between 2 sys_now values (correcting overflows)
+ * 'a' is expected to be 'higher' (without overflow) than 'b'. */
+#define LWIP_TIME_DIFF(a, b) (((a) >= (b)) ? ((a) - (b)) : (((a) + ((b) ^ (0xFFFFFFFF/(TIMER_CLK_FREQ/1000))) + 1)))
+
 /* Critical Region Protection */
 /* These functions must be implemented in the sys_arch.c file.
    In some implementations they can provide a more light-weight protection

--- a/lwip/core/ipv4/ip.c
+++ b/lwip/core/ipv4/ip.c
@@ -518,20 +518,20 @@ ip_napt_find(u8_t proto, u32_t addr, u16_t port, u16_t mport, u8_t dest)
 #if LWIP_TCP
     if (t->proto == IP_PROTO_TCP &&
         (((t->finack1 && t->finack2 || !t->synack) &&
-          now - t->last > IP_NAPT_TIMEOUT_MS_TCP_DISCON) ||
-         now - t->last > ip_napt_tcp_timeout)) {
+	  LWIP_TIME_DIFF(now, t->last) > IP_NAPT_TIMEOUT_MS_TCP_DISCON) ||
+	  LWIP_TIME_DIFF(now, t->last) > ip_napt_tcp_timeout)) {
       ip_napt_free(t);
       continue;
     }
 #endif
 #if LWIP_UDP
-    if (t->proto == IP_PROTO_UDP && now - t->last > ip_napt_udp_timeout) {
+    if (t->proto == IP_PROTO_UDP && LWIP_TIME_DIFF(now, t->last) > ip_napt_udp_timeout) {
       ip_napt_free(t);
       continue;
     }
 #endif
 #if LWIP_ICMP
-    if (t->proto == IP_PROTO_ICMP && now - t->last > IP_NAPT_TIMEOUT_MS_ICMP) {
+    if (t->proto == IP_PROTO_ICMP && LWIP_TIME_DIFF(now, t->last) > IP_NAPT_TIMEOUT_MS_ICMP) {
       ip_napt_free(t);
       continue;
     }


### PR DESCRIPTION
NOW() macro reads RTC2 value to get the time, this value
can wrap up, so handle this with LWIP_TIME_DIFF.
Otherwise connection get lost every ~4 hours.